### PR TITLE
feat: add hourly scraper log monitoring workflow

### DIFF
--- a/.github/workflows/monitor-logs.yml
+++ b/.github/workflows/monitor-logs.yml
@@ -1,0 +1,96 @@
+name: Monitor Scraper Logs
+
+on:
+  schedule:
+    - cron: "0 * * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: monitor-logs
+  cancel-in-progress: true
+
+jobs:
+  check-logs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.10"
+
+      - run: bun install --frozen-lockfile
+
+      - name: Check scraper logs for errors
+        id: check
+        run: bun run scripts/check-logs.ts
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+
+      - name: Check for existing recent issues
+        if: steps.check.outputs.has_errors == 'true'
+        id: existing
+        run: |
+          recent_issues=$(gh issue list \
+            --label "scraper-error" \
+            --state open \
+            --search "scraper error" \
+            --limit 5 \
+            --json title,createdAt,number)
+          echo "recent_issues<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$recent_issues" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Analyze errors with Claude Code
+        if: steps.check.outputs.has_errors == 'true'
+        run: |
+          npm install -g @anthropic-ai/claude-code
+
+          ERROR_LOGS=$(cat /tmp/error-logs.json)
+          EXISTING_ISSUES="${{ steps.existing.outputs.recent_issues }}"
+
+          claude -p "You are analyzing scraper worker error logs for the open-gikai project.
+
+          ## Error Logs (past 1 hour)
+          \`\`\`json
+          ${ERROR_LOGS}
+          \`\`\`
+
+          ## Existing Open Issues (labeled scraper-error)
+          \`\`\`json
+          ${EXISTING_ISSUES}
+          \`\`\`
+
+          ## Instructions
+          1. Analyze the errors and identify root causes.
+          2. Check if any existing open issue already covers this error. If so, add a comment to that issue with the latest occurrence details using 'gh issue comment'.
+          3. If this is a new error not covered by existing issues, create a new GitHub issue with:
+             - A clear title describing the error
+             - Label: scraper-error
+             - Body containing: error summary, affected jobs, timestamps, and suggested fix
+             - Use 'gh issue create' command
+          4. If the fix is straightforward and you can implement it confidently:
+             - Create a new branch from main
+             - Make the fix
+             - Push and create a PR referencing the issue
+             - Use 'gh pr create' command
+          5. If you cannot fix it, just ensure the issue is created/updated.
+
+          Important:
+          - The project uses Bun, Drizzle ORM, Cloudflare Workers
+          - Scraper worker code is in apps/scraper-worker/
+          - DB schema is in packages/db/src/schema/
+          - Do NOT create duplicate issues
+          - Always use the scraper-error label"
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "db:migrate": "turbo -F @open-gikai/db db:migrate",
     "db:seed": "turbo -F @open-gikai/db db:seed",
     "check": "oxlint && oxfmt --write",
-    "scrape:local": "turbo -F @open-gikai/scraper-worker scrape:local"
+    "scrape:local": "turbo -F @open-gikai/scraper-worker scrape:local",
+    "check-logs": "bun run scripts/check-logs.ts"
   },
   "dependencies": {
     "@open-gikai/env": "workspace:*",

--- a/scripts/check-logs.ts
+++ b/scripts/check-logs.ts
@@ -1,0 +1,93 @@
+import { createDb } from "@open-gikai/db";
+import {
+  scraper_job_logs,
+  scraper_jobs,
+} from "@open-gikai/db/schema";
+import { and, eq, gte, inArray } from "drizzle-orm";
+import { appendFile, writeFile } from "node:fs/promises";
+
+const DATABASE_URL = process.env.DATABASE_URL;
+if (!DATABASE_URL) {
+  console.error("DATABASE_URL is required");
+  process.exit(1);
+}
+
+const db = createDb(DATABASE_URL);
+
+const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
+
+// Query error/warn logs from the past hour
+const recentLogs = await db
+  .select({
+    id: scraper_job_logs.id,
+    jobId: scraper_job_logs.jobId,
+    level: scraper_job_logs.level,
+    message: scraper_job_logs.message,
+    createdAt: scraper_job_logs.createdAt,
+  })
+  .from(scraper_job_logs)
+  .where(
+    and(
+      inArray(scraper_job_logs.level, ["error", "warn"]),
+      gte(scraper_job_logs.createdAt, oneHourAgo),
+    ),
+  )
+  .orderBy(scraper_job_logs.createdAt);
+
+// Query failed jobs from the past hour
+const failedJobs = await db
+  .select({
+    id: scraper_jobs.id,
+    municipalityId: scraper_jobs.municipalityId,
+    status: scraper_jobs.status,
+    year: scraper_jobs.year,
+    errorMessage: scraper_jobs.errorMessage,
+    processedItems: scraper_jobs.processedItems,
+    totalItems: scraper_jobs.totalItems,
+    totalInserted: scraper_jobs.totalInserted,
+    totalSkipped: scraper_jobs.totalSkipped,
+    createdAt: scraper_jobs.createdAt,
+    completedAt: scraper_jobs.completedAt,
+  })
+  .from(scraper_jobs)
+  .where(
+    and(
+      eq(scraper_jobs.status, "failed"),
+      gte(scraper_jobs.createdAt, oneHourAgo),
+    ),
+  )
+  .orderBy(scraper_jobs.createdAt);
+
+const errorLogs = recentLogs.filter((l) => l.level === "error");
+const warnLogs = recentLogs.filter((l) => l.level === "warn");
+
+const hasErrors = errorLogs.length > 0 || failedJobs.length > 0;
+
+const summary = {
+  checkedAt: new Date().toISOString(),
+  window: "1 hour",
+  hasErrors,
+  counts: {
+    errorLogs: errorLogs.length,
+    warnLogs: warnLogs.length,
+    failedJobs: failedJobs.length,
+  },
+  errorLogs,
+  warnLogs,
+  failedJobs,
+};
+
+// Output JSON summary to stdout
+console.log(JSON.stringify(summary, null, 2));
+
+// Write detailed error info to /tmp/error-logs.json
+await writeFile("/tmp/error-logs.json", JSON.stringify(summary, null, 2));
+
+// Set GitHub Actions output
+const githubOutput = process.env.GITHUB_OUTPUT;
+if (githubOutput) {
+  await appendFile(githubOutput, `has_errors=${hasErrors}\n`);
+}
+
+// Exit cleanly
+process.exit(0);


### PR DESCRIPTION
## Summary
- Add `scripts/check-logs.ts` - a Bun script that queries `scraper_job_logs` (error/warn) and `scraper_jobs` (failed) from the past hour using the existing `@open-gikai/db` package
- Add `.github/workflows/monitor-logs.yml` - a GitHub Actions workflow that runs hourly, checks for errors, and uses Claude Code CLI to analyze them, create/update GitHub issues (with `scraper-error` label), and optionally create fix PRs
- Add `check-logs` script entry to root `package.json`

## Details
- The check-logs script outputs a JSON summary to stdout, writes details to `/tmp/error-logs.json`, and sets `has_errors` as a GitHub Actions output
- Duplicate issue prevention: the workflow queries existing open issues with `scraper-error` label before invoking Claude Code
- Claude Code is instructed to comment on existing issues rather than creating duplicates
- Requires `DATABASE_URL` and `ANTHROPIC_API_KEY` secrets to be configured

## Test plan
- [ ] Verify `bun run scripts/check-logs.ts` runs locally with a valid `DATABASE_URL`
- [ ] Trigger the workflow manually via `workflow_dispatch` to validate the full pipeline
- [ ] Confirm no duplicate issues are created on repeated runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)