### PR TITLE
feat: スクレイピング進捗管理ページを追加

### DIFF
--- a/apps/web/src/routes/admin/_layout.tsx
+++ b/apps/web/src/routes/admin/_layout.tsx
@@ -33,6 +33,12 @@ function AdminLayout() {
             >
               スクレイパー
             </a>
+            <a
+              href="/admin/progress"
+              className="text-muted-foreground hover:text-foreground"
+            >
+              進捗管理
+            </a>
           </nav>
         </div>
       </div>

--- a/apps/web/src/routes/admin/_layout/progress/index.tsx
+++ b/apps/web/src/routes/admin/_layout/progress/index.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/admin/_layout/progress/")({
+  beforeLoad: () => {
+    throw redirect({ to: "/admin/progress/prefectures" });
+  },
+});

--- a/apps/web/src/routes/admin/_layout/progress/municipalities.tsx
+++ b/apps/web/src/routes/admin/_layout/progress/municipalities.tsx
@@ -1,0 +1,218 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+
+import { orpc } from "@/lib/orpc/orpc";
+import { Badge } from "@/shared/_components/ui/badge";
+import { Button } from "@/shared/_components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/shared/_components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/shared/_components/ui/table";
+import { TabNav } from "./prefectures";
+
+export const Route = createFileRoute("/admin/_layout/progress/municipalities")({
+  validateSearch: (search: Record<string, unknown>) => ({
+    prefecture: (search.prefecture as string) || undefined,
+  }),
+  component: MunicipalitiesPage,
+});
+
+const PREFECTURES = [
+  "北海道", "青森県", "岩手県", "宮城県", "秋田県", "山形県", "福島県",
+  "茨城県", "栃木県", "群馬県", "埼玉県", "千葉県", "東京都", "神奈川県",
+  "新潟県", "富山県", "石川県", "福井県", "山梨県", "長野県",
+  "岐阜県", "静岡県", "愛知県", "三重県",
+  "滋賀県", "京都府", "大阪府", "兵庫県", "奈良県", "和歌山県",
+  "鳥取県", "島根県", "岡山県", "広島県", "山口県",
+  "徳島県", "香川県", "愛媛県", "高知県",
+  "福岡県", "佐賀県", "長崎県", "熊本県", "大分県", "宮崎県", "鹿児島県", "沖縄県",
+];
+
+const PAGE_SIZE = 50;
+
+function MunicipalitiesPage() {
+  const { prefecture: initialPrefecture } = Route.useSearch();
+  const [prefecture, setPrefecture] = useState<string | undefined>(initialPrefecture);
+  const [page, setPage] = useState(0);
+
+  const { data, isLoading } = useQuery(
+    orpc.scrapers.progressByMunicipality.queryOptions({
+      input: {
+        prefecture,
+        limit: PAGE_SIZE,
+        offset: page * PAGE_SIZE,
+      },
+    })
+  );
+
+  const items = data?.items ?? [];
+  const total = data?.total ?? 0;
+
+  const handlePrefectureChange = (value: string) => {
+    setPrefecture(value === "all" ? undefined : value);
+    setPage(0);
+  };
+
+  return (
+    <div className="mx-auto max-w-6xl px-4 py-8 space-y-8">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">進捗管理</h1>
+        <TabNav current="municipalities" />
+      </div>
+
+      <div className="flex items-center gap-4">
+        <Select
+          value={prefecture ?? "all"}
+          onValueChange={handlePrefectureChange}
+        >
+          <SelectTrigger className="w-48">
+            <SelectValue placeholder="都道府県で絞り込み" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">すべて</SelectItem>
+            {PREFECTURES.map((p) => (
+              <SelectItem key={p} value={p}>
+                {p}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <span className="text-sm text-muted-foreground">
+          {total} 件
+        </span>
+      </div>
+
+      <div className="rounded border border-border bg-card">
+        {isLoading ? (
+          <div className="p-8 text-center text-sm text-muted-foreground">
+            読み込み中...
+          </div>
+        ) : items.length === 0 ? (
+          <div className="p-8 text-center text-sm text-muted-foreground">
+            データがありません
+          </div>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="px-4">自治体名</TableHead>
+                <TableHead className="px-4">ジョブ数 (完了/全体)</TableHead>
+                <TableHead className="px-4">会議数</TableHead>
+                <TableHead className="px-4">挿入件数</TableHead>
+                <TableHead className="px-4">ステータス</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {items.map((item) => (
+                <TableRow key={item.municipalityId}>
+                  <TableCell className="px-4">
+                    <span className="text-muted-foreground">
+                      {item.prefecture}
+                    </span>
+                    <span className="ml-1 font-medium">{item.name}</span>
+                  </TableCell>
+                  <TableCell className="px-4 text-muted-foreground">
+                    {item.completedJobs} / {item.totalJobs}
+                  </TableCell>
+                  <TableCell className="px-4 text-muted-foreground">
+                    {item.totalMeetings.toLocaleString("ja-JP")}
+                  </TableCell>
+                  <TableCell className="px-4 text-muted-foreground">
+                    {item.totalInserted.toLocaleString("ja-JP")}
+                  </TableCell>
+                  <TableCell className="px-4">
+                    <MunicipalityStatus item={item} />
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+        {total > PAGE_SIZE && (
+          <div className="flex justify-between items-center px-4 py-3 border-t text-sm">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setPage((p) => Math.max(0, p - 1))}
+              disabled={page === 0}
+            >
+              前へ
+            </Button>
+            <span className="text-muted-foreground">
+              {page + 1} / {Math.ceil(total / PAGE_SIZE)}
+            </span>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setPage((p) => p + 1)}
+              disabled={(page + 1) * PAGE_SIZE >= total}
+            >
+              次へ
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function MunicipalityStatus({
+  item,
+}: {
+  item: {
+    totalJobs: number;
+    completedJobs: number;
+    activeJobs: number;
+  };
+}) {
+  if (item.totalJobs === 0) {
+    return (
+      <Badge
+        variant="outline"
+        className="bg-gray-100 text-gray-700 border-gray-200"
+      >
+        未着手
+      </Badge>
+    );
+  }
+  if (item.activeJobs > 0) {
+    return (
+      <Badge
+        variant="outline"
+        className="bg-blue-100 text-blue-700 border-blue-200"
+      >
+        進行中
+      </Badge>
+    );
+  }
+  if (item.completedJobs === item.totalJobs) {
+    return (
+      <Badge
+        variant="outline"
+        className="bg-green-100 text-green-700 border-green-200"
+      >
+        完了
+      </Badge>
+    );
+  }
+  return (
+    <Badge
+      variant="outline"
+      className="bg-yellow-100 text-yellow-700 border-yellow-200"
+    >
+      一部完了
+    </Badge>
+  );
+}

--- a/apps/web/src/routes/admin/_layout/progress/prefectures.tsx
+++ b/apps/web/src/routes/admin/_layout/progress/prefectures.tsx
@@ -1,0 +1,159 @@
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { useQuery } from "@tanstack/react-query";
+
+import { orpc } from "@/lib/orpc/orpc";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/shared/_components/ui/table";
+import { Badge } from "@/shared/_components/ui/badge";
+
+export const Route = createFileRoute("/admin/_layout/progress/prefectures")({
+  component: PrefecturesPage,
+});
+
+function TabNav({ current }: { current: "prefectures" | "municipalities" | "years" }) {
+  const tabs = [
+    { key: "prefectures" as const, label: "都道府県別", href: "/admin/progress/prefectures" },
+    { key: "municipalities" as const, label: "自治体別", href: "/admin/progress/municipalities" },
+    { key: "years" as const, label: "年度別", href: "/admin/progress/years" },
+  ];
+
+  return (
+    <div className="flex gap-1 rounded-lg bg-muted p-1">
+      {tabs.map((tab) => (
+        <a
+          key={tab.key}
+          href={tab.href}
+          className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+            current === tab.key
+              ? "bg-background text-foreground shadow-sm"
+              : "text-muted-foreground hover:text-foreground"
+          }`}
+        >
+          {tab.label}
+        </a>
+      ))}
+    </div>
+  );
+}
+
+function ProgressBar({ value, max }: { value: number; max: number }) {
+  const pct = max === 0 ? 0 : Math.round((value / max) * 100);
+  return (
+    <div className="flex items-center gap-2">
+      <div className="h-2 w-24 rounded-full bg-gray-200">
+        <div
+          className="h-2 rounded-full bg-green-500 transition-all"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <span className="text-xs text-muted-foreground">{pct}%</span>
+    </div>
+  );
+}
+
+function PrefecturesPage() {
+  const navigate = useNavigate();
+  const { data, isLoading } = useQuery(
+    orpc.scrapers.progressByPrefecture.queryOptions({ input: {} })
+  );
+
+  const rows = data ?? [];
+
+  return (
+    <div className="mx-auto max-w-6xl px-4 py-8 space-y-8">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">進捗管理</h1>
+        <TabNav current="prefectures" />
+      </div>
+
+      <div className="rounded border border-border bg-card">
+        <div className="border-b px-4 py-3 font-semibold text-sm">
+          都道府県別スクレイピング進捗
+        </div>
+        {isLoading ? (
+          <div className="p-8 text-center text-sm text-muted-foreground">
+            読み込み中...
+          </div>
+        ) : rows.length === 0 ? (
+          <div className="p-8 text-center text-sm text-muted-foreground">
+            データがありません
+          </div>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="px-4">都道府県</TableHead>
+                <TableHead className="px-4">自治体数 (済/全体)</TableHead>
+                <TableHead className="px-4">完了率</TableHead>
+                <TableHead className="px-4">ジョブ数</TableHead>
+                <TableHead className="px-4">失敗</TableHead>
+                <TableHead className="px-4">会議数</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {rows.map((row) => (
+                <TableRow
+                  key={row.prefecture}
+                  className="cursor-pointer"
+                  onClick={() => {
+                    navigate({
+                      to: "/admin/progress/municipalities",
+                      search: { prefecture: row.prefecture },
+                    });
+                  }}
+                >
+                  <TableCell className="px-4 font-medium">
+                    {row.prefecture}
+                  </TableCell>
+                  <TableCell className="px-4 text-muted-foreground">
+                    {row.scrapedMunicipalities} / {row.totalMunicipalities}
+                  </TableCell>
+                  <TableCell className="px-4">
+                    <ProgressBar
+                      value={row.scrapedMunicipalities}
+                      max={row.totalMunicipalities}
+                    />
+                  </TableCell>
+                  <TableCell className="px-4 text-muted-foreground">
+                    {row.totalJobs}
+                    {row.activeJobs > 0 && (
+                      <Badge
+                        variant="outline"
+                        className="ml-2 bg-blue-100 text-blue-700 border-blue-200"
+                      >
+                        {row.activeJobs} 実行中
+                      </Badge>
+                    )}
+                  </TableCell>
+                  <TableCell className="px-4">
+                    {row.failedJobs > 0 ? (
+                      <Badge
+                        variant="outline"
+                        className="bg-red-100 text-red-700 border-red-200"
+                      >
+                        {row.failedJobs}
+                      </Badge>
+                    ) : (
+                      <span className="text-muted-foreground">0</span>
+                    )}
+                  </TableCell>
+                  <TableCell className="px-4 text-muted-foreground">
+                    {row.totalMeetings.toLocaleString("ja-JP")}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export { TabNav, ProgressBar };

--- a/apps/web/src/routes/admin/_layout/progress/years.tsx
+++ b/apps/web/src/routes/admin/_layout/progress/years.tsx
@@ -1,0 +1,125 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { useQuery } from "@tanstack/react-query";
+
+import { orpc } from "@/lib/orpc/orpc";
+import { Badge } from "@/shared/_components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/shared/_components/ui/table";
+import { TabNav, ProgressBar } from "./prefectures";
+
+export const Route = createFileRoute("/admin/_layout/progress/years")({
+  component: YearsPage,
+});
+
+function YearsPage() {
+  const { data, isLoading } = useQuery(
+    orpc.scrapers.progressByYear.queryOptions({ input: {} })
+  );
+
+  const rows = data ?? [];
+
+  return (
+    <div className="mx-auto max-w-6xl px-4 py-8 space-y-8">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">進捗管理</h1>
+        <TabNav current="years" />
+      </div>
+
+      <div className="rounded border border-border bg-card">
+        <div className="border-b px-4 py-3 font-semibold text-sm">
+          年度別スクレイピング進捗
+        </div>
+        {isLoading ? (
+          <div className="p-8 text-center text-sm text-muted-foreground">
+            読み込み中...
+          </div>
+        ) : rows.length === 0 ? (
+          <div className="p-8 text-center text-sm text-muted-foreground">
+            データがありません
+          </div>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="px-4">年度</TableHead>
+                <TableHead className="px-4">自治体数 (完了/全体)</TableHead>
+                <TableHead className="px-4">進捗</TableHead>
+                <TableHead className="px-4">ジョブ数</TableHead>
+                <TableHead className="px-4">完了</TableHead>
+                <TableHead className="px-4">失敗</TableHead>
+                <TableHead className="px-4">実行中</TableHead>
+                <TableHead className="px-4">挿入件数</TableHead>
+                <TableHead className="px-4">スキップ件数</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {rows.map((row) => (
+                <TableRow key={row.year}>
+                  <TableCell className="px-4 font-medium">
+                    {row.year}年度
+                  </TableCell>
+                  <TableCell className="px-4 text-muted-foreground">
+                    {row.completedMunicipalities} / {row.totalMunicipalities}
+                  </TableCell>
+                  <TableCell className="px-4">
+                    <ProgressBar
+                      value={row.completedMunicipalities}
+                      max={row.totalMunicipalities}
+                    />
+                  </TableCell>
+                  <TableCell className="px-4 text-muted-foreground">
+                    {row.totalJobs}
+                  </TableCell>
+                  <TableCell className="px-4">
+                    <Badge
+                      variant="outline"
+                      className="bg-green-100 text-green-700 border-green-200"
+                    >
+                      {row.completedJobs}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="px-4">
+                    {row.failedJobs > 0 ? (
+                      <Badge
+                        variant="outline"
+                        className="bg-red-100 text-red-700 border-red-200"
+                      >
+                        {row.failedJobs}
+                      </Badge>
+                    ) : (
+                      <span className="text-muted-foreground">0</span>
+                    )}
+                  </TableCell>
+                  <TableCell className="px-4">
+                    {row.activeJobs > 0 ? (
+                      <Badge
+                        variant="outline"
+                        className="bg-blue-100 text-blue-700 border-blue-200"
+                      >
+                        {row.activeJobs}
+                      </Badge>
+                    ) : (
+                      <span className="text-muted-foreground">0</span>
+                    )}
+                  </TableCell>
+                  <TableCell className="px-4 text-muted-foreground">
+                    {row.totalInserted.toLocaleString("ja-JP")}
+                  </TableCell>
+                  <TableCell className="px-4 text-muted-foreground">
+                    {row.totalSkipped.toLocaleString("ja-JP")}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/api/src/routers/scrapers/_schemas/index.ts
+++ b/packages/api/src/routers/scrapers/_schemas/index.ts
@@ -5,3 +5,6 @@ export { scrapersCancelJobSchema } from "./scrapers-cancel-job.schema";
 export { scrapersGetJobLogsSchema } from "./scrapers-get-job-logs.schema";
 export { scrapersListMunicipalitiesSchema } from "./scrapers-list-municipalities.schema";
 export { scrapersReprocessStatementsSchema } from "./scrapers-reprocess-statements.schema";
+export { scrapersProgressByPrefectureSchema } from "./scrapers-progress-by-prefecture.schema";
+export { scrapersProgressByMunicipalitySchema } from "./scrapers-progress-by-municipality.schema";
+export { scrapersProgressByYearSchema } from "./scrapers-progress-by-year.schema";

--- a/packages/api/src/routers/scrapers/_schemas/scrapers-progress-by-municipality.schema.ts
+++ b/packages/api/src/routers/scrapers/_schemas/scrapers-progress-by-municipality.schema.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const scrapersProgressByMunicipalitySchema = z.object({
+  prefecture: z.string().optional(),
+  limit: z.number().int().min(1).max(100).default(50),
+  offset: z.number().int().min(0).default(0),
+});

--- a/packages/api/src/routers/scrapers/_schemas/scrapers-progress-by-prefecture.schema.ts
+++ b/packages/api/src/routers/scrapers/_schemas/scrapers-progress-by-prefecture.schema.ts
@@ -1,0 +1,3 @@
+import { z } from "zod";
+
+export const scrapersProgressByPrefectureSchema = z.object({});

--- a/packages/api/src/routers/scrapers/_schemas/scrapers-progress-by-year.schema.ts
+++ b/packages/api/src/routers/scrapers/_schemas/scrapers-progress-by-year.schema.ts
@@ -1,0 +1,3 @@
+import { z } from "zod";
+
+export const scrapersProgressByYearSchema = z.object({});

--- a/packages/api/src/routers/scrapers/scrapers.router.ts
+++ b/packages/api/src/routers/scrapers/scrapers.router.ts
@@ -7,6 +7,9 @@ import {
   scrapersGetJobLogsSchema,
   scrapersListMunicipalitiesSchema,
   scrapersReprocessStatementsSchema,
+  scrapersProgressByPrefectureSchema,
+  scrapersProgressByMunicipalitySchema,
+  scrapersProgressByYearSchema,
 } from "./_schemas";
 import {
   listJobs,
@@ -16,6 +19,9 @@ import {
   getJobLogs,
   listMunicipalities,
   reprocessStatements,
+  progressByPrefecture,
+  progressByMunicipality,
+  progressByYear,
 } from "./scrapers.service";
 
 export const scrapersRouter = {
@@ -46,4 +52,16 @@ export const scrapersRouter = {
   reprocessStatements: adminProcedure
     .input(scrapersReprocessStatementsSchema)
     .handler(({ input, context }) => reprocessStatements(context.db, input)),
+
+  progressByPrefecture: adminProcedure
+    .input(scrapersProgressByPrefectureSchema)
+    .handler(({ input, context }) => progressByPrefecture(context.db, input)),
+
+  progressByMunicipality: adminProcedure
+    .input(scrapersProgressByMunicipalitySchema)
+    .handler(({ input, context }) => progressByMunicipality(context.db, input)),
+
+  progressByYear: adminProcedure
+    .input(scrapersProgressByYearSchema)
+    .handler(({ input, context }) => progressByYear(context.db, input)),
 };

--- a/packages/api/src/routers/scrapers/scrapers.service.ts
+++ b/packages/api/src/routers/scrapers/scrapers.service.ts
@@ -2,7 +2,7 @@ import type { Db } from "@open-gikai/db";
 import { scraper_jobs, scraper_job_logs, municipalities, system_types } from "@open-gikai/db";
 import { meetings, statements } from "@open-gikai/db/schema";
 import { ORPCError } from "@orpc/server";
-import { asc, desc, eq, inArray } from "drizzle-orm";
+import { asc, count, countDistinct, desc, eq, inArray, sql } from "drizzle-orm";
 import { z } from "zod";
 import type {
   scrapersListJobsSchema,
@@ -12,6 +12,9 @@ import type {
   scrapersGetJobLogsSchema,
   scrapersListMunicipalitiesSchema,
   scrapersReprocessStatementsSchema,
+  scrapersProgressByPrefectureSchema,
+  scrapersProgressByMunicipalitySchema,
+  scrapersProgressByYearSchema,
 } from "./_schemas";
 export interface ScraperJob {
   id: string;
@@ -261,4 +264,192 @@ export async function getJobLogs(
       createdAt: row.createdAt,
     })),
   };
+}
+
+// ── Progress queries ──────────────────────────────────────────
+
+export interface PrefectureProgress {
+  prefecture: string;
+  totalMunicipalities: number;
+  scrapedMunicipalities: number;
+  totalJobs: number;
+  completedJobs: number;
+  failedJobs: number;
+  activeJobs: number;
+  totalMeetings: number;
+}
+
+export async function progressByPrefecture(
+  db: Db,
+  _input: z.infer<typeof scrapersProgressByPrefectureSchema>
+): Promise<PrefectureProgress[]> {
+  // Query 1: job-level stats grouped by prefecture
+  const jobStats = await db
+    .select({
+      prefecture: municipalities.prefecture,
+      totalMunicipalities: count(municipalities.id),
+      scrapedMunicipalities: sql<number>`count(distinct case when ${scraper_jobs.status} = 'completed' then ${municipalities.id} end)`.as("scraped_municipalities"),
+      totalJobs: sql<number>`count(${scraper_jobs.id})`.as("total_jobs"),
+      completedJobs: sql<number>`count(case when ${scraper_jobs.status} = 'completed' then 1 end)`.as("completed_jobs"),
+      failedJobs: sql<number>`count(case when ${scraper_jobs.status} = 'failed' then 1 end)`.as("failed_jobs"),
+      activeJobs: sql<number>`count(case when ${scraper_jobs.status} in ('pending', 'queued', 'running') then 1 end)`.as("active_jobs"),
+    })
+    .from(municipalities)
+    .leftJoin(scraper_jobs, eq(municipalities.id, scraper_jobs.municipalityId))
+    .groupBy(municipalities.prefecture)
+    .orderBy(asc(municipalities.prefecture));
+
+  // Query 2: meeting counts grouped by prefecture
+  const meetingStats = await db
+    .select({
+      prefecture: municipalities.prefecture,
+      totalMeetings: count(meetings.id),
+    })
+    .from(meetings)
+    .innerJoin(municipalities, eq(meetings.municipalityId, municipalities.id))
+    .groupBy(municipalities.prefecture);
+
+  const meetingMap = new Map(
+    meetingStats.map((r) => [r.prefecture, Number(r.totalMeetings)])
+  );
+
+  return jobStats.map((r) => ({
+    prefecture: r.prefecture,
+    totalMunicipalities: Number(r.totalMunicipalities),
+    scrapedMunicipalities: Number(r.scrapedMunicipalities),
+    totalJobs: Number(r.totalJobs),
+    completedJobs: Number(r.completedJobs),
+    failedJobs: Number(r.failedJobs),
+    activeJobs: Number(r.activeJobs),
+    totalMeetings: meetingMap.get(r.prefecture) ?? 0,
+  }));
+}
+
+export interface MunicipalityProgress {
+  municipalityId: string;
+  name: string;
+  prefecture: string;
+  totalJobs: number;
+  completedJobs: number;
+  failedJobs: number;
+  activeJobs: number;
+  totalMeetings: number;
+  totalInserted: number;
+}
+
+export interface MunicipalityProgressResponse {
+  items: MunicipalityProgress[];
+  total: number;
+}
+
+export async function progressByMunicipality(
+  db: Db,
+  input: z.infer<typeof scrapersProgressByMunicipalitySchema>
+): Promise<MunicipalityProgressResponse> {
+  const whereClause = input.prefecture
+    ? eq(municipalities.prefecture, input.prefecture)
+    : undefined;
+
+  // Main query with pagination
+  const rows = await db
+    .select({
+      municipalityId: municipalities.id,
+      name: municipalities.name,
+      prefecture: municipalities.prefecture,
+      totalJobs: sql<number>`count(${scraper_jobs.id})`.as("total_jobs"),
+      completedJobs: sql<number>`count(case when ${scraper_jobs.status} = 'completed' then 1 end)`.as("completed_jobs"),
+      failedJobs: sql<number>`count(case when ${scraper_jobs.status} = 'failed' then 1 end)`.as("failed_jobs"),
+      activeJobs: sql<number>`count(case when ${scraper_jobs.status} in ('pending', 'queued', 'running') then 1 end)`.as("active_jobs"),
+      totalInserted: sql<number>`coalesce(sum(${scraper_jobs.totalInserted}), 0)`.as("total_inserted"),
+    })
+    .from(municipalities)
+    .leftJoin(scraper_jobs, eq(municipalities.id, scraper_jobs.municipalityId))
+    .where(whereClause)
+    .groupBy(municipalities.id, municipalities.name, municipalities.prefecture)
+    .orderBy(asc(municipalities.prefecture), asc(municipalities.name))
+    .limit(input.limit)
+    .offset(input.offset);
+
+  // Count total
+  const totalResult = whereClause
+    ? await db.$count(municipalities, whereClause)
+    : await db.$count(municipalities);
+
+  // Meeting counts for the municipalities in the current page
+  const municipalityIds = rows.map((r) => r.municipalityId);
+  let meetingMap = new Map<string, number>();
+  if (municipalityIds.length > 0) {
+    const meetingStats = await db
+      .select({
+        municipalityId: meetings.municipalityId,
+        totalMeetings: count(meetings.id),
+      })
+      .from(meetings)
+      .where(inArray(meetings.municipalityId, municipalityIds))
+      .groupBy(meetings.municipalityId);
+
+    meetingMap = new Map(
+      meetingStats.map((r) => [r.municipalityId, Number(r.totalMeetings)])
+    );
+  }
+
+  return {
+    items: rows.map((r) => ({
+      municipalityId: r.municipalityId,
+      name: r.name,
+      prefecture: r.prefecture,
+      totalJobs: Number(r.totalJobs),
+      completedJobs: Number(r.completedJobs),
+      failedJobs: Number(r.failedJobs),
+      activeJobs: Number(r.activeJobs),
+      totalMeetings: meetingMap.get(r.municipalityId) ?? 0,
+      totalInserted: Number(r.totalInserted),
+    })),
+    total: totalResult,
+  };
+}
+
+export interface YearProgress {
+  year: number;
+  totalMunicipalities: number;
+  completedMunicipalities: number;
+  totalJobs: number;
+  completedJobs: number;
+  failedJobs: number;
+  activeJobs: number;
+  totalInserted: number;
+  totalSkipped: number;
+}
+
+export async function progressByYear(
+  db: Db,
+  _input: z.infer<typeof scrapersProgressByYearSchema>
+): Promise<YearProgress[]> {
+  const rows = await db
+    .select({
+      year: scraper_jobs.year,
+      totalMunicipalities: countDistinct(scraper_jobs.municipalityId),
+      completedMunicipalities: sql<number>`count(distinct case when ${scraper_jobs.status} = 'completed' then ${scraper_jobs.municipalityId} end)`.as("completed_municipalities"),
+      totalJobs: count(scraper_jobs.id),
+      completedJobs: sql<number>`count(case when ${scraper_jobs.status} = 'completed' then 1 end)`.as("completed_jobs"),
+      failedJobs: sql<number>`count(case when ${scraper_jobs.status} = 'failed' then 1 end)`.as("failed_jobs"),
+      activeJobs: sql<number>`count(case when ${scraper_jobs.status} in ('pending', 'queued', 'running') then 1 end)`.as("active_jobs"),
+      totalInserted: sql<number>`coalesce(sum(${scraper_jobs.totalInserted}), 0)`.as("total_inserted"),
+      totalSkipped: sql<number>`coalesce(sum(${scraper_jobs.totalSkipped}), 0)`.as("total_skipped"),
+    })
+    .from(scraper_jobs)
+    .groupBy(scraper_jobs.year)
+    .orderBy(desc(scraper_jobs.year));
+
+  return rows.map((r) => ({
+    year: r.year,
+    totalMunicipalities: Number(r.totalMunicipalities),
+    completedMunicipalities: Number(r.completedMunicipalities),
+    totalJobs: Number(r.totalJobs),
+    completedJobs: Number(r.completedJobs),
+    failedJobs: Number(r.failedJobs),
+    activeJobs: Number(r.activeJobs),
+    totalInserted: Number(r.totalInserted),
+    totalSkipped: Number(r.totalSkipped),
+  }));
 }


### PR DESCRIPTION
## Summary
- 都道府県別・自治体別・年度別の3つのビューでスクレイピング進捗を可視化する管理画面を追加
- 既存テーブル（municipalities, scraper_jobs, meetings）の集計クエリを使用し、新規DBテーブルは不要
- `/admin/progress` 配下に3つのタブページ（prefectures / municipalities / years）を作成

## 変更内容
### API（packages/api）
- `progressByPrefecture`: 都道府県ごとの自治体数・ジョブ数・会議数を集計
- `progressByMunicipality`: 自治体ごとの進捗（都道府県フィルタ・ページネーション対応）
- `progressByYear`: 年度ごとのジョブ数・挿入件数・スキップ件数を集計

### UI（apps/web）
- 都道府県別ページ: プログレスバー付きテーブル、行クリックで自治体一覧へ遷移
- 自治体別ページ: 都道府県フィルタ・ページネーション・ステータスバッジ
- 年度別ページ: 年度降順テーブル、完了/失敗/実行中のバッジ表示
- ナビゲーションに「進捗管理」リンクを追加

## Test plan
- [ ] `/admin/progress` にアクセスすると `/admin/progress/prefectures` にリダイレクトされる
- [ ] 都道府県別ページでテーブルが表示され、行クリックで自治体別ページに遷移する
- [ ] 自治体別ページで都道府県フィルタとページネーションが動作する
- [ ] 年度別ページで年度降順にデータが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)