### PR TITLE
feat: 待機中ジョブの一括削除ボタンを追加

### DIFF
--- a/apps/web/src/routes/admin/_layout/scrapers/index.tsx
+++ b/apps/web/src/routes/admin/_layout/scrapers/index.tsx
@@ -75,6 +75,15 @@ function ScrapersPage() {
     onError: (err) => toast.error(`エラー: ${err.message}`),
   });
 
+  const deletePendingMutation = useMutation({
+    mutationFn: () => client.scrapers.deletePendingJobs({}),
+    onSuccess: (data) => {
+      toast.success(`${data.deletedCount} 件の待機中ジョブを削除しました`);
+      queryClient.invalidateQueries({ queryKey: orpc.scrapers.listJobs.key() });
+    },
+    onError: (err) => toast.error(`エラー: ${err.message}`),
+  });
+
   return (
     <div className="mx-auto max-w-6xl px-4 py-8 space-y-8">
       <h1 className="text-2xl font-bold">スクレイパー管理</h1>
@@ -93,6 +102,27 @@ function ScrapersPage() {
         onSubmit={(payload) => reprocessMutation.mutate(payload)}
         isSubmitting={reprocessMutation.isPending}
       />
+
+      <div className="rounded border border-border bg-card p-4 space-y-2">
+        <div>
+          <h2 className="font-semibold text-sm">待機中ジョブ一括削除</h2>
+          <p className="text-xs text-muted-foreground mt-1">
+            ステータスが pending のジョブをすべて削除します。
+          </p>
+        </div>
+        <Button
+          variant="destructive"
+          size="sm"
+          disabled={deletePendingMutation.isPending}
+          onClick={() => {
+            if (window.confirm("待機中（pending）のジョブをすべて削除しますか？")) {
+              deletePendingMutation.mutate();
+            }
+          }}
+        >
+          {deletePendingMutation.isPending ? "削除中..." : "待機中ジョブを削除"}
+        </Button>
+      </div>
 
       <div className="rounded border border-border bg-card">
         <div className="border-b px-4 py-3 font-semibold text-sm">

--- a/packages/api/src/routers/scrapers/_schemas/index.ts
+++ b/packages/api/src/routers/scrapers/_schemas/index.ts
@@ -9,3 +9,4 @@ export { scrapersReprocessStatementsSchema } from "./scrapers-reprocess-statemen
 export { scrapersProgressByPrefectureSchema } from "./scrapers-progress-by-prefecture.schema";
 export { scrapersProgressByMunicipalitySchema } from "./scrapers-progress-by-municipality.schema";
 export { scrapersProgressByYearSchema } from "./scrapers-progress-by-year.schema";
+export { scrapersDeletePendingJobsSchema } from "./scrapers-delete-pending-jobs.schema";

--- a/packages/api/src/routers/scrapers/_schemas/scrapers-delete-pending-jobs.schema.ts
+++ b/packages/api/src/routers/scrapers/_schemas/scrapers-delete-pending-jobs.schema.ts
@@ -1,0 +1,3 @@
+import { z } from "zod";
+
+export const scrapersDeletePendingJobsSchema = z.object({});

--- a/packages/api/src/routers/scrapers/scrapers.router.ts
+++ b/packages/api/src/routers/scrapers/scrapers.router.ts
@@ -11,6 +11,7 @@ import {
   scrapersProgressByPrefectureSchema,
   scrapersProgressByMunicipalitySchema,
   scrapersProgressByYearSchema,
+  scrapersDeletePendingJobsSchema,
 } from "./_schemas";
 import {
   listJobs,
@@ -24,6 +25,7 @@ import {
   progressByPrefecture,
   progressByMunicipality,
   progressByYear,
+  deletePendingJobs,
 } from "./scrapers.service";
 
 export const scrapersRouter = {
@@ -70,4 +72,8 @@ export const scrapersRouter = {
   progressByYear: adminProcedure
     .input(scrapersProgressByYearSchema)
     .handler(({ input, context }) => progressByYear(context.db, input)),
+
+  deletePendingJobs: adminProcedure
+    .input(scrapersDeletePendingJobsSchema)
+    .handler(({ input, context }) => deletePendingJobs(context.db, input)),
 };

--- a/packages/api/src/routers/scrapers/scrapers.service.ts
+++ b/packages/api/src/routers/scrapers/scrapers.service.ts
@@ -16,6 +16,7 @@ import type {
   scrapersProgressByPrefectureSchema,
   scrapersProgressByMunicipalitySchema,
   scrapersProgressByYearSchema,
+  scrapersDeletePendingJobsSchema,
 } from "./_schemas";
 export interface ScraperJob {
   id: string;
@@ -333,6 +334,22 @@ export async function getJobLogs(
       createdAt: row.createdAt,
     })),
   };
+}
+
+export interface DeletePendingJobsResponse {
+  deletedCount: number;
+}
+
+export async function deletePendingJobs(
+  db: Db,
+  _input: z.infer<typeof scrapersDeletePendingJobsSchema>
+): Promise<DeletePendingJobsResponse> {
+  const deleted = await db
+    .delete(scraper_jobs)
+    .where(eq(scraper_jobs.status, "pending"))
+    .returning({ id: scraper_jobs.id });
+
+  return { deletedCount: deleted.length };
 }
 
 // ── Progress queries ──────────────────────────────────────────


### PR DESCRIPTION
## Summary
- admin/scrapersページにpendingステータスのジョブを一括削除するボタンを追加
- バックエンドに `deletePendingJobs` oRPCプロシージャを追加
- 確認ダイアログ付きで、削除件数をトーストで表示

## Test plan
- [ ] admin/scrapersページに「待機中ジョブ一括削除」セクションが表示される
- [ ] ボタンクリックで確認ダイアログが表示される
- [ ] 実行後、pendingジョブが削除されジョブ一覧が更新される
- [ ] running/completed等のジョブは削除されない

🤖 Generated with [Claude Code](https://claude.com/claude-code)