### PR TITLE
モバイルでフォーム要素タップ時の自動ズームを防止

### DIFF
--- a/apps/web/src/shared/_components/municipality-selector.tsx
+++ b/apps/web/src/shared/_components/municipality-selector.tsx
@@ -114,7 +114,7 @@ export function MunicipalitySelector({ selectedCodes, onChange, required = false
             setIsOpen(true);
           }}
           onFocus={() => setIsOpen(true)}
-          className="text-sm"
+          className="text-base md:text-sm"
           role="combobox"
           aria-expanded={isOpen}
           aria-controls={listboxId}

--- a/apps/web/src/shared/_components/ui/command.tsx
+++ b/apps/web/src/shared/_components/ui/command.tsx
@@ -71,7 +71,7 @@ function CommandInput({
       <CommandPrimitive.Input
         data-slot="command-input"
         className={cn(
-          "flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-10 w-full rounded-md bg-transparent py-3 text-base md:text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         {...props}

--- a/apps/web/src/shared/_components/ui/native-select.tsx
+++ b/apps/web/src/shared/_components/ui/native-select.tsx
@@ -24,7 +24,7 @@ function NativeSelect({
       <select
         data-slot="native-select"
         data-size={size}
-        className="h-8 w-full min-w-0 appearance-none rounded-none border border-input bg-transparent py-1 pr-8 pl-2.5 text-xs transition-colors outline-none select-none selection:bg-primary selection:text-primary-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed aria-invalid:border-destructive aria-invalid:ring-1 aria-invalid:ring-destructive/20 data-[size=sm]:h-7 data-[size=sm]:rounded-none data-[size=sm]:py-0.5 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40"
+        className="h-8 w-full min-w-0 appearance-none rounded-none border border-input bg-transparent py-1 pr-8 pl-2.5 text-base md:text-xs transition-colors outline-none select-none selection:bg-primary selection:text-primary-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed aria-invalid:border-destructive aria-invalid:ring-1 aria-invalid:ring-destructive/20 data-[size=sm]:h-7 data-[size=sm]:rounded-none data-[size=sm]:py-0.5 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40"
         {...props}
       />
       <ChevronDownIcon className="pointer-events-none absolute top-1/2 right-2.5 size-4 -translate-y-1/2 text-muted-foreground select-none" aria-hidden="true" data-slot="native-select-icon" />


### PR DESCRIPTION
## Summary
- iOS Safariで`font-size < 16px`のフォーム要素をタップすると自動ズームが発生する問題を修正
- `municipality-selector`、`native-select`、`command`の3コンポーネントでモバイル時に`text-base`(16px)を適用
- デスクトップでは従来通りの小さいフォントサイズを維持（`md:text-sm`/`md:text-xs`）

## Test plan
- [ ] iOSまたはChromeデバイスエミュレータで検索ページを開き、自治体セレクターをタップしてズームされないことを確認
- [ ] 会議一覧ページのフィルター（NativeSelect）をタップしてズームされないことを確認
- [ ] デスクトップではフォントサイズが変わっていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)