### PR TITLE
feat: DB インポートスクリプトで自治体コードを引数指定可能にする

### DIFF
--- a/packages/db/seeds/insert-to-pgsql-prd.ts
+++ b/packages/db/seeds/insert-to-pgsql-prd.ts
@@ -6,6 +6,7 @@
  *
  * 使い方:
  *   DATABASE_URL_FOR_PRD_IMPORT="postgresql://..." bun run db:import:prd
+ *   DATABASE_URL_FOR_PRD_IMPORT="postgresql://..." bun run db:import:prd 011002 012025  # 特定の自治体のみ
  *
  * - _complete が存在し、かつ imported フラグが立っていないディレクトリのみ処理する
  * - 各ディレクトリの処理成功後に _complete へ imported フラグを記録する
@@ -36,7 +37,13 @@ async function main() {
     process.exit(1);
   }
 
-  const targets = collectImportTargets(dataDir, { skipImported: true });
+  const municipalityCodes = process.argv.slice(2).filter((arg) => !arg.startsWith("-"));
+
+  if (municipalityCodes.length > 0) {
+    console.log(`[import:prd] 対象自治体コード: ${municipalityCodes.join(", ")}`);
+  }
+
+  const targets = collectImportTargets(dataDir, { skipImported: true, municipalityCodes });
 
   if (targets.length === 0) {
     console.log(

--- a/packages/db/seeds/insert-to-pgsql.ts
+++ b/packages/db/seeds/insert-to-pgsql.ts
@@ -6,6 +6,7 @@
  *
  * 使い方:
  *   DATABASE_URL="postgresql://..." bun run db:import
+ *   DATABASE_URL="postgresql://..." bun run db:import 011002 012025  # 特定の自治体のみ
  *
  * - _complete が存在するディレクトリをすべて処理する（imported フラグは無視）
  * - imported フラグの記録は行わない
@@ -36,7 +37,13 @@ async function main() {
     process.exit(1);
   }
 
-  const targets = collectImportTargets(dataDir, { skipImported: false });
+  const municipalityCodes = process.argv.slice(2).filter((arg) => !arg.startsWith("-"));
+
+  if (municipalityCodes.length > 0) {
+    console.log(`[import] 対象自治体コード: ${municipalityCodes.join(", ")}`);
+  }
+
+  const targets = collectImportTargets(dataDir, { skipImported: false, municipalityCodes });
 
   if (targets.length === 0) {
     console.log(

--- a/packages/db/seeds/utils/collect-import-targets.test.ts
+++ b/packages/db/seeds/utils/collect-import-targets.test.ts
@@ -99,4 +99,41 @@ describe("collectImportTargets", () => {
     const targets = collectImportTargets(dataDir, { skipImported: false });
     expect(targets).toHaveLength(3);
   });
+
+  test("municipalityCodes を指定すると該当コードのみ収集する", () => {
+    for (const [year, code] of [["2024", "011002"], ["2024", "012025"], ["2025", "011002"]]) {
+      const codeDir = join(dataDir, year!, code!);
+      mkdirSync(codeDir, { recursive: true });
+      writeFileSync(join(codeDir, "_complete"), JSON.stringify({ completedAt: "2025-01-01T00:00:00.000Z", meetings: 1 }));
+      writeFileSync(join(codeDir, "meetings.ndjson"), "{}");
+    }
+
+    const targets = collectImportTargets(dataDir, { skipImported: false, municipalityCodes: ["012025"] });
+    expect(targets).toHaveLength(1);
+    expect(targets[0]!.codeDir).toBe(join(dataDir, "2024", "012025"));
+  });
+
+  test("municipalityCodes を複数指定すると該当コードすべてを収集する", () => {
+    for (const [year, code] of [["2024", "011002"], ["2024", "012025"], ["2025", "011002"]]) {
+      const codeDir = join(dataDir, year!, code!);
+      mkdirSync(codeDir, { recursive: true });
+      writeFileSync(join(codeDir, "_complete"), JSON.stringify({ completedAt: "2025-01-01T00:00:00.000Z", meetings: 1 }));
+      writeFileSync(join(codeDir, "meetings.ndjson"), "{}");
+    }
+
+    const targets = collectImportTargets(dataDir, { skipImported: false, municipalityCodes: ["011002", "012025"] });
+    expect(targets).toHaveLength(3);
+  });
+
+  test("municipalityCodes が空配列の場合はフィルタしない", () => {
+    for (const [year, code] of [["2024", "011002"], ["2024", "012025"]]) {
+      const codeDir = join(dataDir, year!, code!);
+      mkdirSync(codeDir, { recursive: true });
+      writeFileSync(join(codeDir, "_complete"), JSON.stringify({ completedAt: "2025-01-01T00:00:00.000Z", meetings: 1 }));
+      writeFileSync(join(codeDir, "meetings.ndjson"), "{}");
+    }
+
+    const targets = collectImportTargets(dataDir, { skipImported: false, municipalityCodes: [] });
+    expect(targets).toHaveLength(2);
+  });
 });

--- a/packages/db/seeds/utils/collect-import-targets.ts
+++ b/packages/db/seeds/utils/collect-import-targets.ts
@@ -11,6 +11,8 @@ export interface ImportTarget {
 export interface CollectOptions {
   /** true の場合、imported 済みディレクトリをスキップする（本番用） */
   skipImported: boolean;
+  /** 指定した場合、この自治体コードに一致するディレクトリのみ対象にする */
+  municipalityCodes?: string[];
 }
 
 /**
@@ -31,6 +33,11 @@ export function collectImportTargets(dataDir: string, options: CollectOptions): 
     for (const codeEntry of readdirSync(yearDir)) {
       const codeDir = resolve(yearDir, codeEntry);
       if (!statSync(codeDir).isDirectory()) continue;
+
+      // municipalityCodes が指定されている場合、一致しないコードをスキップ
+      if (options.municipalityCodes && options.municipalityCodes.length > 0) {
+        if (!options.municipalityCodes.includes(codeEntry)) continue;
+      }
 
       // _complete が存在しない場合はスキップする
       const completePath = resolve(codeDir, "_complete");


### PR DESCRIPTION
## Summary
- `db:import` / `db:import:prd` に自治体コード（例: `011002 012025`）を引数で渡すと、該当自治体のみ処理する
- 引数なしの場合は従来通り全件処理
- `collectImportTargets` に `municipalityCodes` フィルタオプションを追加

## Test plan
- [x] `collectImportTargets` のユニットテスト追加（単一コード / 複数コード / 空配列）
- [ ] `bun run db:import 011002` でローカル動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)