### PR TITLE
feat: 議題ベース Q&A エージェントを packages/api へ移植

### DIFF
--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -15,6 +15,7 @@ import { Route as MeetingsIndexRouteImport } from './routes/meetings/index'
 import { Route as MeetingsMeetingIdRouteImport } from './routes/meetings/$meetingId'
 import { Route as AdminLayoutRouteImport } from './routes/admin/_layout'
 import { Route as AdminLayoutIndexRouteImport } from './routes/admin/_layout/index'
+import { Route as AdminLayoutAskRouteImport } from './routes/admin/_layout/ask'
 import { Route as authSignUpIndexRouteImport } from './routes/(auth)/sign-up/index'
 import { Route as authSignInIndexRouteImport } from './routes/(auth)/sign-in/index'
 import { Route as ApiRpcSplatRouteImport } from './routes/api/rpc/$'
@@ -49,6 +50,11 @@ const AdminLayoutRoute = AdminLayoutRouteImport.update({
 const AdminLayoutIndexRoute = AdminLayoutIndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => AdminLayoutRoute,
+} as any)
+const AdminLayoutAskRoute = AdminLayoutAskRouteImport.update({
+  id: '/ask',
+  path: '/ask',
   getParentRoute: () => AdminLayoutRoute,
 } as any)
 const authSignUpIndexRoute = authSignUpIndexRouteImport.update({
@@ -88,6 +94,7 @@ export interface FileRoutesByFullPath {
   '/sign-in/': typeof authSignInIndexRoute
   '/sign-up/': typeof authSignUpIndexRoute
   '/admin/': typeof AdminLayoutIndexRoute
+  '/admin/ask': typeof AdminLayoutAskRoute
   '/sign-up/otp/': typeof authSignUpOtpIndexRoute
 }
 export interface FileRoutesByTo {
@@ -100,6 +107,7 @@ export interface FileRoutesByTo {
   '/sign-in': typeof authSignInIndexRoute
   '/sign-up': typeof authSignUpIndexRoute
   '/admin': typeof AdminLayoutIndexRoute
+  '/admin/ask': typeof AdminLayoutAskRoute
   '/sign-up/otp': typeof authSignUpOtpIndexRoute
 }
 export interface FileRoutesById {
@@ -114,6 +122,7 @@ export interface FileRoutesById {
   '/(auth)/sign-in/': typeof authSignInIndexRoute
   '/(auth)/sign-up/': typeof authSignUpIndexRoute
   '/admin/_layout/': typeof AdminLayoutIndexRoute
+  '/admin/_layout/ask': typeof AdminLayoutAskRoute
   '/(auth)/sign-up/otp/': typeof authSignUpOtpIndexRoute
 }
 export interface FileRouteTypes {
@@ -129,6 +138,7 @@ export interface FileRouteTypes {
     | '/sign-in/'
     | '/sign-up/'
     | '/admin/'
+    | '/admin/ask'
     | '/sign-up/otp/'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -141,6 +151,7 @@ export interface FileRouteTypes {
     | '/sign-in'
     | '/sign-up'
     | '/admin'
+    | '/admin/ask'
     | '/sign-up/otp'
   id:
     | '__root__'
@@ -154,6 +165,7 @@ export interface FileRouteTypes {
     | '/(auth)/sign-in/'
     | '/(auth)/sign-up/'
     | '/admin/_layout/'
+    | '/admin/_layout/ask'
     | '/(auth)/sign-up/otp/'
   fileRoutesById: FileRoutesById
 }
@@ -214,6 +226,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AdminLayoutIndexRouteImport
       parentRoute: typeof AdminLayoutRoute
     }
+    '/admin/_layout/ask': {
+      id: '/admin/_layout/ask'
+      path: '/ask'
+      fullPath: '/admin/ask'
+      preLoaderRoute: typeof AdminLayoutAskRouteImport
+      parentRoute: typeof AdminLayoutRoute
+    }
     '/(auth)/sign-up/': {
       id: '/(auth)/sign-up/'
       path: '/sign-up'
@@ -254,10 +273,12 @@ declare module '@tanstack/react-router' {
 
 interface AdminLayoutRouteChildren {
   AdminLayoutIndexRoute: typeof AdminLayoutIndexRoute
+  AdminLayoutAskRoute: typeof AdminLayoutAskRoute
 }
 
 const AdminLayoutRouteChildren: AdminLayoutRouteChildren = {
   AdminLayoutIndexRoute: AdminLayoutIndexRoute,
+  AdminLayoutAskRoute: AdminLayoutAskRoute,
 }
 
 const AdminLayoutRouteWithChildren = AdminLayoutRoute._addFileChildren(

--- a/apps/web/src/routes/admin/_layout.tsx
+++ b/apps/web/src/routes/admin/_layout.tsx
@@ -27,6 +27,12 @@ function AdminLayout() {
             >
               ダッシュボード
             </a>
+            <a
+              href="/admin/ask"
+              className="font-medium text-foreground hover:text-primary"
+            >
+              ask
+            </a>
           </nav>
         </div>
       </div>

--- a/apps/web/src/routes/admin/_layout/ask.tsx
+++ b/apps/web/src/routes/admin/_layout/ask.tsx
@@ -1,0 +1,219 @@
+import { useState } from "react";
+import { createFileRoute } from "@tanstack/react-router";
+import { useMutation, useQuery } from "@tanstack/react-query";
+
+import { orpc } from "@/lib/orpc/orpc";
+import { Button } from "@/shared/_components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/shared/_components/ui/card";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/shared/_components/ui/collapsible";
+import { Input } from "@/shared/_components/ui/input";
+import { Label } from "@/shared/_components/ui/label";
+import { Textarea } from "@/shared/_components/ui/textarea";
+import { MunicipalitySelector } from "@/shared/_components/municipality-selector";
+
+export const Route = createFileRoute("/admin/_layout/ask")({
+  component: AdminAskPage,
+});
+
+function AdminAskPage() {
+  return (
+    <div className="mx-auto max-w-6xl px-4 py-8 space-y-8">
+      <h1 className="text-2xl font-bold">Ask 動作確認</h1>
+      <TopicsSearchSection />
+      <MeetingsAskSection />
+    </div>
+  );
+}
+
+function TopicsSearchSection() {
+  const [selectedCodes, setSelectedCodes] = useState<string[]>([]);
+  const [query, setQuery] = useState("");
+  const [committedQuery, setCommittedQuery] = useState("");
+  const [committedCode, setCommittedCode] = useState<string | undefined>(undefined);
+
+  const enabled = committedQuery.length > 0;
+
+  const { data, isFetching, error } = useQuery({
+    ...orpc.topics.search.queryOptions({
+      input: {
+        query: committedQuery,
+        municipalityCode: committedCode,
+        limit: 30,
+      },
+    }),
+    enabled,
+  });
+
+  const rows = data?.rows ?? [];
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!query.trim()) return;
+    setCommittedQuery(query.trim());
+    setCommittedCode(selectedCodes[0]);
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>議題キーワード検索</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <MunicipalitySelector selectedCodes={selectedCodes} onChange={setSelectedCodes} />
+        <p className="text-xs text-muted-foreground">
+          複数選択しても先頭 1 件のみ検索条件に使われます（API 側が単一自治体指定のみ対応）。
+        </p>
+        <form onSubmit={onSubmit} className="flex flex-col gap-2">
+          <Label htmlFor="topics-query">キーワード</Label>
+          <div className="flex gap-2">
+            <Input
+              id="topics-query"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="例: 市バス路線再編"
+            />
+            <Button type="submit" disabled={!query.trim()}>
+              検索
+            </Button>
+          </div>
+        </form>
+
+        {error && (
+          <p className="text-sm text-destructive">エラー: {error.message}</p>
+        )}
+
+        {enabled && (
+          <div className="space-y-2">
+            <div className="text-xs text-muted-foreground">
+              {isFetching ? "検索中..." : `${rows.length} 件ヒット`}
+            </div>
+            {rows.map((r) => (
+              <Card key={`${r.meetingId}-${r.matchedTopic}`} className="border">
+                <CardContent className="py-3 space-y-1 text-sm">
+                  <div className="flex items-center gap-2">
+                    <span className="font-semibold">{r.title}</span>
+                    <span className="text-xs text-muted-foreground">({r.heldOn})</span>
+                    <span className="text-xs text-muted-foreground">[{r.meetingType}]</span>
+                  </div>
+                  <div>
+                    <span className="font-medium">議題:</span> {r.matchedTopic}{" "}
+                    <span className="text-xs text-muted-foreground">({r.relevance})</span>
+                  </div>
+                  <div className="text-xs text-muted-foreground whitespace-pre-wrap">
+                    {r.digestPreview}
+                  </div>
+                  <div className="text-xs font-mono text-muted-foreground">
+                    meetingId: {r.meetingId}
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function MeetingsAskSection() {
+  const [municipalityCode, setMunicipalityCode] = useState("");
+  const [question, setQuestion] = useState("");
+
+  const mutation = useMutation(orpc.meetings.ask.mutationOptions());
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!question.trim()) return;
+    mutation.mutate({
+      question: question.trim(),
+      municipalityCode: municipalityCode.trim() || undefined,
+    });
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>エージェントに質問</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <form onSubmit={onSubmit} className="space-y-3">
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="ask-municipality">自治体コード（任意・単一）</Label>
+            <Input
+              id="ask-municipality"
+              value={municipalityCode}
+              onChange={(e) => setMunicipalityCode(e.target.value)}
+              placeholder="例: 462012"
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="ask-question">質問</Label>
+            <Textarea
+              id="ask-question"
+              value={question}
+              onChange={(e) => setQuestion(e.target.value)}
+              placeholder="例: 市バス路線再編について時系列で整理して"
+              rows={5}
+            />
+          </div>
+          <Button type="submit" disabled={!question.trim() || mutation.isPending}>
+            {mutation.isPending ? "問い合わせ中..." : "聞く"}
+          </Button>
+        </form>
+
+        {mutation.error && (
+          <p className="text-sm text-destructive">エラー: {mutation.error.message}</p>
+        )}
+
+        {mutation.data && (
+          <div className="space-y-3">
+            <div className="flex gap-4 text-xs text-muted-foreground">
+              <span>iterations: {mutation.data.iterations}</span>
+              <span>input tokens: {mutation.data.inputTokens}</span>
+              <span>output tokens: {mutation.data.outputTokens}</span>
+            </div>
+            <Card className="border">
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm">回答</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <pre className="whitespace-pre-wrap text-sm font-sans">
+                  {mutation.data.answer}
+                </pre>
+              </CardContent>
+            </Card>
+
+            <Collapsible>
+              <CollapsibleTrigger asChild>
+                <Button variant="outline" size="sm">
+                  trace を表示 ({mutation.data.trace.length} 件)
+                </Button>
+              </CollapsibleTrigger>
+              <CollapsibleContent className="mt-2 space-y-2">
+                {mutation.data.trace.map((t, idx) => (
+                  <Card key={idx} className="border">
+                    <CardContent className="py-2 space-y-1 text-xs">
+                      <div className="font-semibold">
+                        #{idx + 1} {t.tool}
+                      </div>
+                      <div className="font-mono text-muted-foreground break-all">
+                        args: {JSON.stringify(t.args)}
+                      </div>
+                      <div className="text-muted-foreground">
+                        result: {t.resultSummary}
+                      </div>
+                    </CardContent>
+                  </Card>
+                ))}
+              </CollapsibleContent>
+            </Collapsible>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/bun.lock
+++ b/bun.lock
@@ -115,6 +115,7 @@
     "packages/api": {
       "name": "@open-gikai/api",
       "dependencies": {
+        "@google/genai": "^1.50.1",
         "@open-gikai/auth": "workspace:*",
         "@open-gikai/db": "workspace:*",
         "@orpc/client": "catalog:",
@@ -1827,9 +1828,9 @@
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
-    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
-    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
     "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
 
@@ -2537,8 +2538,6 @@
 
     "@tanstack/start-plugin-core/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
-    "accepts/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
-
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "c12/chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
@@ -2565,9 +2564,9 @@
 
     "express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
-    "express/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
-
     "fetch-blob/web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
+
+    "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "gaxios/node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 
@@ -2615,8 +2614,6 @@
 
     "router/path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
 
-    "send/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
-
     "shadcn/node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 
     "shadcn/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
@@ -2628,8 +2625,6 @@
     "strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "tsx/esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
-
-    "type-is/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
     "vite/esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
 
@@ -2705,8 +2700,6 @@
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.18.20", "", { "os": "win32", "cpu": "x64" }, "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ=="],
 
-    "accepts/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
-
     "c12/chokidar/readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
     "cliui/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
@@ -2715,7 +2708,7 @@
 
     "cross-spawn/which/isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
-    "express/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+    "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "msw/tough-cookie/tldts": ["tldts@7.0.24", "", { "dependencies": { "tldts-core": "^7.0.24" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-1r6vQTTt1rUiJkI5vX7KG8PR342Ru/5Oh13kEQP2SMbRSZpOey9SrBe27IDxkoWulx8ShWu4K6C0BkctP8Z1bQ=="],
 
@@ -2724,8 +2717,6 @@
     "node-fetch/whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
     "openai/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
-
-    "send/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "tsx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
 
@@ -2778,8 +2769,6 @@
     "tsx/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q=="],
 
     "tsx/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.3", "", { "os": "win32", "cpu": "x64" }, "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA=="],
-
-    "type-is/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -13,6 +13,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@google/genai": "^1.50.1",
     "@open-gikai/auth": "workspace:*",
     "@open-gikai/db": "workspace:*",
     "@orpc/client": "catalog:",

--- a/packages/api/src/routers/index.ts
+++ b/packages/api/src/routers/index.ts
@@ -4,11 +4,13 @@ import type { RouterClient } from "@orpc/server";
 import { statementsRouter } from "./statements/statements.router";
 import { meetingsRouter } from "./meetings/meetings.router";
 import { municipalitiesRouter } from "./municipalities/municipalities.router";
+import { topicsRouter } from "./topics/topics.router";
 
 export const appRouter = {
   statements: statementsRouter,
   meetings: meetingsRouter,
   municipalities: municipalitiesRouter,
+  topics: topicsRouter,
 };
 export type AppRouter = typeof appRouter;
 export type AppRouterClient = RouterClient<typeof appRouter>;

--- a/packages/api/src/routers/meetings/_schemas/index.ts
+++ b/packages/api/src/routers/meetings/_schemas/index.ts
@@ -1,2 +1,3 @@
 export { meetingsListSchema } from "./meetings-list.schema";
 export { meetingStatementsSchema } from "./meeting-statements.schema";
+export { meetingsAskSchema } from "./meetings-ask.schema";

--- a/packages/api/src/routers/meetings/_schemas/meetings-ask.schema.ts
+++ b/packages/api/src/routers/meetings/_schemas/meetings-ask.schema.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const meetingsAskSchema = z.object({
+  question: z.string().min(1),
+  municipalityCode: z.string().optional(),
+  model: z.string().default("gemini-2.5-flash-lite"),
+});

--- a/packages/api/src/routers/meetings/meetings.router.ts
+++ b/packages/api/src/routers/meetings/meetings.router.ts
@@ -1,6 +1,14 @@
 import { publicProcedure } from "../../index";
-import { meetingsListSchema, meetingStatementsSchema } from "./_schemas";
-import { listMeetings, getMeetingStatements } from "./meetings.service";
+import {
+  meetingsAskSchema,
+  meetingsListSchema,
+  meetingStatementsSchema,
+} from "./_schemas";
+import {
+  askMeetings,
+  getMeetingStatements,
+  listMeetings,
+} from "./meetings.service";
 
 export const meetingsRouter = {
   list: publicProcedure
@@ -10,4 +18,8 @@ export const meetingsRouter = {
   statements: publicProcedure
     .input(meetingStatementsSchema)
     .handler(({ input, context }) => getMeetingStatements(context.db, input)),
+
+  ask: publicProcedure
+    .input(meetingsAskSchema)
+    .handler(({ input, context }) => askMeetings(context.db, input)),
 };

--- a/packages/api/src/routers/meetings/meetings.service.ts
+++ b/packages/api/src/routers/meetings/meetings.service.ts
@@ -1,9 +1,26 @@
 import type { Db } from "@open-gikai/db";
 import { meetings, municipalities, statements } from "@open-gikai/db/schema";
+import {
+  GoogleGenAI,
+  type Content,
+  type FunctionCall,
+  type Tool,
+} from "@google/genai";
+import { ORPCError } from "@orpc/server";
 import { and, asc, desc, eq, gte, inArray, like, lte, lt } from "drizzle-orm";
 import { z } from "zod";
 
-import type { meetingsListSchema, meetingStatementsSchema } from "./_schemas";
+import { callWithRetry } from "../../shared/retry";
+import {
+  findMeetingsWithTopics,
+  getMeetingDigest,
+  searchTopics,
+} from "../topics/topics.service";
+import type {
+  meetingsListSchema,
+  meetingStatementsSchema,
+  meetingsAskSchema,
+} from "./_schemas";
 
 export interface MeetingListItem {
   id: string;
@@ -117,4 +134,268 @@ export async function getMeetingStatements(
     ...(meeting as MeetingListItem),
     statements: statementRows as MeetingStatement[],
   };
+}
+
+const MAX_ASK_ITERATIONS = 15;
+
+const ASK_SYSTEM_PROMPT = `あなたは地方議会の議事録サマリを検索し、ユーザーの質問に時系列で整理した議論の流れを提示するアシスタントです。
+
+# 使えるツール
+
+- \`search_topics(query, municipality_code?, date_from?, date_to?)\`: 議題名・ダイジェスト本文・会議サマリのいずれかに \`query\` が含まれる会議を、新しい順に返す
+- \`get_meeting_digest(meeting_id)\`: 特定の会議のサマリと全 topic_digests を取得する
+- \`find_meetings_with_topics(topics, municipality_code?)\`: 複数の議題すべてを扱っている会議を返す（関連分析用）
+
+# 手順
+
+1. ユーザーの質問から検索キーワードを抽出し、\`search_topics\` で関連会議を探す
+2. 関連度が高そうな会議について \`get_meeting_digest\` で詳細を取得し、該当 topic の digest を確認する
+3. 複数議題の関連を問う質問なら \`find_meetings_with_topics\` を使う
+4. 集めた情報を **時系列（古い→新しい）** に整理し、以下のフォーマットで回答する:
+
+   ## 〇〇について
+
+   ### 議論の流れ（〜年）
+   - 〇〇年〇月: [会議名] で △△議員が〜と質問し、当局は〜と回答
+   - ...
+
+   ### 主なポイント
+   - ...
+
+   ### 関連議題（あれば）
+   - ...
+
+# ルール
+
+- 必ずツールで取得した情報のみに基づいて回答する。推測や一般論で埋めない
+- 日付・数字・固有名詞は省略せず引用する
+- 情報が見つからない場合は「該当する議事録サマリは見つかりませんでした」と率直に回答する
+- ツールを最大 ${MAX_ASK_ITERATIONS - 1} 回まで呼べる。無駄な呼び出しは避ける`;
+
+const ASK_TOOLS: Tool[] = [
+  {
+    functionDeclarations: [
+      {
+        name: "search_topics",
+        description:
+          "議題名・ダイジェスト本文・会議全体サマリのいずれかにクエリが含まれる会議を新しい順で返す。",
+        parametersJsonSchema: {
+          type: "object",
+          properties: {
+            query: {
+              type: "string",
+              description: "検索キーワード（日本語）。部分一致で検索される",
+            },
+            municipality_code: {
+              type: "string",
+              description:
+                "自治体コード（例: 462012 = 鹿児島市）。絞り込みたい場合に指定",
+            },
+            date_from: {
+              type: "string",
+              description: "開催日の下限 (YYYY-MM-DD)",
+            },
+            date_to: {
+              type: "string",
+              description: "開催日の上限 (YYYY-MM-DD)",
+            },
+            limit: {
+              type: "integer",
+              description: "返却件数上限（デフォルト 30）",
+            },
+          },
+          required: ["query"],
+        },
+      },
+      {
+        name: "get_meeting_digest",
+        description:
+          "特定の会議の全サマリ情報（summary + topic_digests 配列）を取得する。",
+        parametersJsonSchema: {
+          type: "object",
+          properties: {
+            meeting_id: { type: "string" },
+          },
+          required: ["meeting_id"],
+        },
+      },
+      {
+        name: "find_meetings_with_topics",
+        description:
+          "複数の議題すべてを同じ会議内で扱っている会議を返す。関連性の分析に使う。",
+        parametersJsonSchema: {
+          type: "object",
+          properties: {
+            topics: {
+              type: "array",
+              items: { type: "string" },
+              description:
+                "すべてにマッチすることを要求するキーワードの配列（2〜3 個推奨）",
+            },
+            municipality_code: { type: "string" },
+            limit: { type: "integer" },
+          },
+          required: ["topics"],
+        },
+      },
+    ],
+  },
+];
+
+export interface AskMeetingsTraceEntry {
+  tool: string;
+  args: unknown;
+  resultSummary: string;
+}
+
+export interface AskMeetingsResponse {
+  answer: string;
+  iterations: number;
+  inputTokens: number;
+  outputTokens: number;
+  trace: AskMeetingsTraceEntry[];
+}
+
+export async function askMeetings(
+  db: Db,
+  input: z.input<typeof meetingsAskSchema>,
+): Promise<AskMeetingsResponse> {
+  const apiKey = process.env.GEMINI_API_KEY ?? process.env.GOOGLE_API_KEY;
+  if (!apiKey) {
+    throw new ORPCError("INTERNAL_SERVER_ERROR", {
+      message: "GEMINI_API_KEY is not configured",
+    });
+  }
+
+  const model = input.model ?? "gemini-2.5-flash-lite";
+  const client = new GoogleGenAI({ apiKey });
+
+  const contextHint = input.municipalityCode
+    ? `(検索対象の自治体コードは ${input.municipalityCode} です。search_topics / find_meetings_with_topics にはこの municipality_code を渡してください)`
+    : "";
+
+  const history: Content[] = [
+    {
+      role: "user",
+      parts: [{ text: `${input.question}\n\n${contextHint}`.trim() }],
+    },
+  ];
+
+  const trace: AskMeetingsTraceEntry[] = [];
+  let totalInputTokens = 0;
+  let totalOutputTokens = 0;
+
+  for (let iter = 0; iter < MAX_ASK_ITERATIONS; iter++) {
+    const response = await callWithRetry(() =>
+      client.models.generateContent({
+        model,
+        contents: history,
+        config: {
+          systemInstruction: ASK_SYSTEM_PROMPT,
+          tools: ASK_TOOLS,
+        },
+      }),
+    );
+
+    totalInputTokens += response.usageMetadata?.promptTokenCount ?? 0;
+    totalOutputTokens += response.usageMetadata?.candidatesTokenCount ?? 0;
+
+    const parts = response.candidates?.[0]?.content?.parts ?? [];
+    history.push({ role: "model", parts });
+
+    const functionCalls = parts
+      .map((p) => p.functionCall)
+      .filter((fc): fc is FunctionCall => Boolean(fc));
+
+    if (functionCalls.length === 0) {
+      const finalText = parts
+        .map((p) => p.text)
+        .filter((t): t is string => Boolean(t))
+        .join("");
+      return {
+        answer: finalText,
+        iterations: iter + 1,
+        inputTokens: totalInputTokens,
+        outputTokens: totalOutputTokens,
+        trace,
+      };
+    }
+
+    const functionResponses = [];
+    for (const call of functionCalls) {
+      const result = await executeAskFunction(db, input.municipalityCode, call);
+      trace.push({
+        tool: call.name ?? "unknown",
+        args: call.args ?? {},
+        resultSummary: summarizeAskResult(result),
+      });
+      functionResponses.push({
+        functionResponse: {
+          name: call.name,
+          response: result as Record<string, unknown>,
+        },
+      });
+    }
+    history.push({ role: "user", parts: functionResponses });
+  }
+
+  return {
+    answer: "",
+    iterations: MAX_ASK_ITERATIONS,
+    inputTokens: totalInputTokens,
+    outputTokens: totalOutputTokens,
+    trace,
+  };
+}
+
+async function executeAskFunction(
+  db: Db,
+  defaultMunicipality: string | undefined,
+  call: FunctionCall,
+): Promise<unknown> {
+  const a = (call.args ?? {}) as Record<string, unknown>;
+  try {
+    switch (call.name) {
+      case "search_topics":
+        return {
+          rows: await searchTopics(db, {
+            query: String(a.query ?? ""),
+            municipalityCode:
+              (a.municipality_code as string | undefined) ?? defaultMunicipality,
+            dateFrom: a.date_from as string | undefined,
+            dateTo: a.date_to as string | undefined,
+            limit: a.limit as number | undefined,
+          }),
+        };
+      case "get_meeting_digest": {
+        const digest = await getMeetingDigest(db, String(a.meeting_id));
+        return digest ?? { error: "not found" };
+      }
+      case "find_meetings_with_topics":
+        return {
+          rows: await findMeetingsWithTopics(db, {
+            topics: (a.topics as string[]) ?? [],
+            municipalityCode:
+              (a.municipality_code as string | undefined) ?? defaultMunicipality,
+            limit: a.limit as number | undefined,
+          }),
+        };
+      default:
+        return { error: `unknown function: ${call.name}` };
+    }
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+function summarizeAskResult(result: unknown): string {
+  if (typeof result !== "object" || result === null) return String(result);
+  const r = result as Record<string, unknown>;
+  if (Array.isArray(r.rows)) return `rows=${r.rows.length}`;
+  if (r.error) return `error: ${String(r.error)}`;
+  if (r.meetingId)
+    return `meeting=${r.title ?? ""} (${r.heldOn ?? ""}) topics=${
+      Array.isArray(r.topicDigests) ? r.topicDigests.length : 0
+    }`;
+  return JSON.stringify(r).slice(0, 120);
 }

--- a/packages/api/src/routers/topics/_schemas/index.ts
+++ b/packages/api/src/routers/topics/_schemas/index.ts
@@ -1,0 +1,1 @@
+export { topicsSearchSchema } from "./topics-search.schema";

--- a/packages/api/src/routers/topics/_schemas/topics-search.schema.ts
+++ b/packages/api/src/routers/topics/_schemas/topics-search.schema.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const topicsSearchSchema = z.object({
+  query: z.string().min(1),
+  municipalityCode: z.string().optional(),
+  dateFrom: z.string().optional(),
+  dateTo: z.string().optional(),
+  limit: z.number().int().min(1).max(100).default(30),
+});

--- a/packages/api/src/routers/topics/topics.router.ts
+++ b/packages/api/src/routers/topics/topics.router.ts
@@ -1,0 +1,11 @@
+import { publicProcedure } from "../../index";
+import { topicsSearchSchema } from "./_schemas";
+import { searchTopics } from "./topics.service";
+
+export const topicsRouter = {
+  search: publicProcedure
+    .input(topicsSearchSchema)
+    .handler(async ({ input, context }) => ({
+      rows: await searchTopics(context.db, input),
+    })),
+};

--- a/packages/api/src/routers/topics/topics.service.test.ts
+++ b/packages/api/src/routers/topics/topics.service.test.ts
@@ -1,0 +1,579 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import {
+  getTestDb,
+  withRollback,
+  createTestDatabase,
+  runMigrations,
+  closeTestDb,
+} from "@open-gikai/db/test-helpers";
+import { meetings, municipalities } from "@open-gikai/db/schema";
+import {
+  findMeetingsWithTopics,
+  getMeetingDigest,
+  searchTopics,
+} from "./topics.service";
+
+type TestDb = ReturnType<typeof getTestDb>;
+
+let db: TestDb;
+
+beforeAll(async () => {
+  await createTestDatabase();
+  db = getTestDb();
+  await runMigrations(db);
+});
+
+afterAll(async () => {
+  await closeTestDb(db);
+});
+
+describe("searchTopics", () => {
+  it("topic 名がマッチする会議を返す", async () => {
+    await withRollback(db, async (tx) => {
+      await tx.insert(municipalities).values({
+        code: "462012",
+        name: "鹿児島市",
+        prefecture: "鹿児島県",
+      });
+      const [meeting] = await tx
+        .insert(meetings)
+        .values({
+          municipalityCode: "462012",
+          title: "令和6年第2回定例会",
+          meetingType: "定例会",
+          heldOn: "2024-06-01",
+          summary: "今回は様々な議論があった。",
+          topicDigests: [
+            {
+              topic: "市バス路線再編",
+              relevance: "primary",
+              digest: "市バス路線再編についての議論",
+              speakers: ["田中議員"],
+            },
+            {
+              topic: "防災計画",
+              relevance: "secondary",
+              digest: "防災計画の見直し",
+              speakers: ["山本議員"],
+            },
+          ],
+        })
+        .returning();
+
+      const rows = await searchTopics(tx, { query: "市バス" });
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.meetingId).toBe(meeting!.id);
+      expect(rows[0]!.matchedTopic).toBe("市バス路線再編");
+      expect(rows[0]!.relevance).toBe("primary");
+      expect(rows[0]!.digestPreview).toBe("市バス路線再編についての議論");
+      expect(rows[0]!.heldOn).toBe("2024-06-01");
+    });
+  });
+
+  it("digest 本文に query が含まれる場合もマッチする", async () => {
+    await withRollback(db, async (tx) => {
+      await tx.insert(municipalities).values({
+        code: "462012",
+        name: "鹿児島市",
+        prefecture: "鹿児島県",
+      });
+      await tx.insert(meetings).values({
+        municipalityCode: "462012",
+        title: "令和6年第1回定例会",
+        meetingType: "定例会",
+        heldOn: "2024-03-01",
+        topicDigests: [
+          {
+            topic: "交通政策",
+            relevance: "primary",
+            digest: "ICカード事業の進捗について議論された",
+            speakers: ["佐藤議員"],
+          },
+        ],
+      });
+
+      const rows = await searchTopics(tx, { query: "ICカード" });
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.matchedTopic).toBe("交通政策");
+    });
+  });
+
+  it("会議の summary に query が含まれる場合もマッチする", async () => {
+    await withRollback(db, async (tx) => {
+      await tx.insert(municipalities).values({
+        code: "462012",
+        name: "鹿児島市",
+        prefecture: "鹿児島県",
+      });
+      await tx.insert(meetings).values({
+        municipalityCode: "462012",
+        title: "令和6年第3回定例会",
+        meetingType: "定例会",
+        heldOn: "2024-09-01",
+        summary: "教育委員会の改革について議論が行われた",
+        topicDigests: [
+          {
+            topic: "一般質問",
+            relevance: "primary",
+            digest: "市政全般に関する一般質問",
+            speakers: [],
+          },
+        ],
+      });
+
+      const rows = await searchTopics(tx, { query: "教育委員会" });
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.matchedTopic).toBe("一般質問");
+    });
+  });
+
+  it("municipalityCode でフィルタできる", async () => {
+    await withRollback(db, async (tx) => {
+      await tx.insert(municipalities).values([
+        { code: "462012", name: "鹿児島市", prefecture: "鹿児島県" },
+        { code: "131001", name: "千代田区", prefecture: "東京都" },
+      ]);
+      await tx.insert(meetings).values([
+        {
+          municipalityCode: "462012",
+          title: "鹿児島の会議",
+          meetingType: "定例会",
+          heldOn: "2024-06-01",
+          topicDigests: [
+            {
+              topic: "観光振興",
+              relevance: "primary",
+              digest: "観光客誘致について",
+              speakers: [],
+            },
+          ],
+        },
+        {
+          municipalityCode: "131001",
+          title: "千代田の会議",
+          meetingType: "定例会",
+          heldOn: "2024-06-01",
+          topicDigests: [
+            {
+              topic: "観光振興",
+              relevance: "primary",
+              digest: "観光客誘致について",
+              speakers: [],
+            },
+          ],
+        },
+      ]);
+
+      const rows = await searchTopics(tx, {
+        query: "観光",
+        municipalityCode: "462012",
+      });
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.title).toBe("鹿児島の会議");
+    });
+  });
+
+  it("dateFrom / dateTo で開催日フィルタ", async () => {
+    await withRollback(db, async (tx) => {
+      await tx.insert(municipalities).values({
+        code: "462012",
+        name: "鹿児島市",
+        prefecture: "鹿児島県",
+      });
+      await tx.insert(meetings).values([
+        {
+          municipalityCode: "462012",
+          title: "古い会議",
+          meetingType: "定例会",
+          heldOn: "2023-03-01",
+          topicDigests: [
+            {
+              topic: "防災",
+              relevance: "primary",
+              digest: "防災について",
+              speakers: [],
+            },
+          ],
+        },
+        {
+          municipalityCode: "462012",
+          title: "新しい会議",
+          meetingType: "定例会",
+          heldOn: "2024-06-01",
+          topicDigests: [
+            {
+              topic: "防災",
+              relevance: "primary",
+              digest: "防災について",
+              speakers: [],
+            },
+          ],
+        },
+      ]);
+
+      const rows = await searchTopics(tx, {
+        query: "防災",
+        dateFrom: "2024-01-01",
+        dateTo: "2024-12-31",
+      });
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.title).toBe("新しい会議");
+    });
+  });
+
+  it("heldOn 降順でソートされる", async () => {
+    await withRollback(db, async (tx) => {
+      await tx.insert(municipalities).values({
+        code: "462012",
+        name: "鹿児島市",
+        prefecture: "鹿児島県",
+      });
+      await tx.insert(meetings).values([
+        {
+          municipalityCode: "462012",
+          title: "3月会議",
+          meetingType: "定例会",
+          heldOn: "2024-03-01",
+          topicDigests: [
+            { topic: "防災", relevance: "primary", digest: "防災", speakers: [] },
+          ],
+        },
+        {
+          municipalityCode: "462012",
+          title: "9月会議",
+          meetingType: "定例会",
+          heldOn: "2024-09-01",
+          topicDigests: [
+            { topic: "防災", relevance: "primary", digest: "防災", speakers: [] },
+          ],
+        },
+        {
+          municipalityCode: "462012",
+          title: "6月会議",
+          meetingType: "定例会",
+          heldOn: "2024-06-01",
+          topicDigests: [
+            { topic: "防災", relevance: "primary", digest: "防災", speakers: [] },
+          ],
+        },
+      ]);
+
+      const rows = await searchTopics(tx, { query: "防災" });
+
+      expect(rows).toHaveLength(3);
+      expect(rows[0]!.title).toBe("9月会議");
+      expect(rows[1]!.title).toBe("6月会議");
+      expect(rows[2]!.title).toBe("3月会議");
+    });
+  });
+
+  it("limit で件数制限できる", async () => {
+    await withRollback(db, async (tx) => {
+      await tx.insert(municipalities).values({
+        code: "462012",
+        name: "鹿児島市",
+        prefecture: "鹿児島県",
+      });
+      await tx.insert(meetings).values([
+        {
+          municipalityCode: "462012",
+          title: "会議A",
+          meetingType: "定例会",
+          heldOn: "2024-03-01",
+          topicDigests: [
+            { topic: "防災", relevance: "primary", digest: "防災", speakers: [] },
+          ],
+        },
+        {
+          municipalityCode: "462012",
+          title: "会議B",
+          meetingType: "定例会",
+          heldOn: "2024-06-01",
+          topicDigests: [
+            { topic: "防災", relevance: "primary", digest: "防災", speakers: [] },
+          ],
+        },
+      ]);
+
+      const rows = await searchTopics(tx, { query: "防災", limit: 1 });
+
+      expect(rows).toHaveLength(1);
+    });
+  });
+
+  it("topic_digests が null の会議はマッチしない", async () => {
+    await withRollback(db, async (tx) => {
+      await tx.insert(municipalities).values({
+        code: "462012",
+        name: "鹿児島市",
+        prefecture: "鹿児島県",
+      });
+      await tx.insert(meetings).values({
+        municipalityCode: "462012",
+        title: "topic_digests なし",
+        meetingType: "定例会",
+        heldOn: "2024-06-01",
+        summary: "防災について",
+      });
+
+      const rows = await searchTopics(tx, { query: "防災" });
+
+      expect(rows).toHaveLength(0);
+    });
+  });
+});
+
+describe("getMeetingDigest", () => {
+  it("会議のサマリと topic_digests を取得できる", async () => {
+    await withRollback(db, async (tx) => {
+      await tx.insert(municipalities).values({
+        code: "462012",
+        name: "鹿児島市",
+        prefecture: "鹿児島県",
+      });
+      const [meeting] = await tx
+        .insert(meetings)
+        .values({
+          municipalityCode: "462012",
+          title: "令和6年第2回定例会",
+          meetingType: "定例会",
+          heldOn: "2024-06-01",
+          sourceUrl: "https://example.com/meeting",
+          summary: "今回は防災と交通の議論があった。",
+          topicDigests: [
+            {
+              topic: "防災",
+              relevance: "primary",
+              digest: "防災計画の見直しについて",
+              speakers: ["田中議員"],
+            },
+            {
+              topic: "交通",
+              relevance: "secondary",
+              digest: "市バスの運行について",
+              speakers: ["佐藤議員"],
+            },
+          ],
+        })
+        .returning();
+
+      const digest = await getMeetingDigest(tx, meeting!.id);
+
+      expect(digest).not.toBeNull();
+      expect(digest!.meetingId).toBe(meeting!.id);
+      expect(digest!.title).toBe("令和6年第2回定例会");
+      expect(digest!.heldOn).toBe("2024-06-01");
+      expect(digest!.meetingType).toBe("定例会");
+      expect(digest!.sourceUrl).toBe("https://example.com/meeting");
+      expect(digest!.summary).toBe("今回は防災と交通の議論があった。");
+      expect(digest!.topicDigests).toHaveLength(2);
+      expect(digest!.topicDigests[0]!.topic).toBe("防災");
+      expect(digest!.topicDigests[1]!.topic).toBe("交通");
+    });
+  });
+
+  it("存在しない meetingId では null を返す", async () => {
+    await withRollback(db, async (tx) => {
+      const digest = await getMeetingDigest(tx, "nonexistent-id");
+
+      expect(digest).toBeNull();
+    });
+  });
+
+  it("topic_digests が null の場合は空配列を返す", async () => {
+    await withRollback(db, async (tx) => {
+      await tx.insert(municipalities).values({
+        code: "462012",
+        name: "鹿児島市",
+        prefecture: "鹿児島県",
+      });
+      const [meeting] = await tx
+        .insert(meetings)
+        .values({
+          municipalityCode: "462012",
+          title: "topic_digests なしの会議",
+          meetingType: "定例会",
+          heldOn: "2024-06-01",
+        })
+        .returning();
+
+      const digest = await getMeetingDigest(tx, meeting!.id);
+
+      expect(digest).not.toBeNull();
+      expect(digest!.topicDigests).toHaveLength(0);
+      expect(digest!.summary).toBeNull();
+    });
+  });
+});
+
+describe("findMeetingsWithTopics", () => {
+  it("複数 topic すべてにマッチする会議を返す", async () => {
+    await withRollback(db, async (tx) => {
+      await tx.insert(municipalities).values({
+        code: "462012",
+        name: "鹿児島市",
+        prefecture: "鹿児島県",
+      });
+      const [matched] = await tx
+        .insert(meetings)
+        .values({
+          municipalityCode: "462012",
+          title: "両方の議題を含む会議",
+          meetingType: "定例会",
+          heldOn: "2024-06-01",
+          topicDigests: [
+            {
+              topic: "市バス路線再編",
+              relevance: "primary",
+              digest: "路線の再編について議論",
+              speakers: [],
+            },
+            {
+              topic: "市バスICカード事業",
+              relevance: "primary",
+              digest: "ICカード導入について議論",
+              speakers: [],
+            },
+          ],
+        })
+        .returning();
+      await tx.insert(meetings).values({
+        municipalityCode: "462012",
+        title: "片方しか含まない会議",
+        meetingType: "定例会",
+        heldOn: "2024-03-01",
+        topicDigests: [
+          {
+            topic: "市バス路線再編",
+            relevance: "primary",
+            digest: "路線の再編について議論",
+            speakers: [],
+          },
+        ],
+      });
+
+      const rows = await findMeetingsWithTopics(tx, {
+        topics: ["市バス路線再編", "ICカード"],
+      });
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.meetingId).toBe(matched!.id);
+      expect(rows[0]!.matchedTopicsByQuery["市バス路線再編"]).toContain(
+        "市バス路線再編",
+      );
+      expect(rows[0]!.matchedTopicsByQuery["ICカード"]).toContain(
+        "市バスICカード事業",
+      );
+    });
+  });
+
+  it("topics が空配列のとき空配列を返す", async () => {
+    await withRollback(db, async (tx) => {
+      const rows = await findMeetingsWithTopics(tx, { topics: [] });
+
+      expect(rows).toHaveLength(0);
+    });
+  });
+
+  it("municipalityCode でフィルタできる", async () => {
+    await withRollback(db, async (tx) => {
+      await tx.insert(municipalities).values([
+        { code: "462012", name: "鹿児島市", prefecture: "鹿児島県" },
+        { code: "131001", name: "千代田区", prefecture: "東京都" },
+      ]);
+      await tx.insert(meetings).values([
+        {
+          municipalityCode: "462012",
+          title: "鹿児島の会議",
+          meetingType: "定例会",
+          heldOn: "2024-06-01",
+          topicDigests: [
+            {
+              topic: "防災A",
+              relevance: "primary",
+              digest: "防災A",
+              speakers: [],
+            },
+            {
+              topic: "防災B",
+              relevance: "primary",
+              digest: "防災B",
+              speakers: [],
+            },
+          ],
+        },
+        {
+          municipalityCode: "131001",
+          title: "千代田の会議",
+          meetingType: "定例会",
+          heldOn: "2024-06-01",
+          topicDigests: [
+            {
+              topic: "防災A",
+              relevance: "primary",
+              digest: "防災A",
+              speakers: [],
+            },
+            {
+              topic: "防災B",
+              relevance: "primary",
+              digest: "防災B",
+              speakers: [],
+            },
+          ],
+        },
+      ]);
+
+      const rows = await findMeetingsWithTopics(tx, {
+        topics: ["防災A", "防災B"],
+        municipalityCode: "462012",
+      });
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.title).toBe("鹿児島の会議");
+    });
+  });
+
+  it("heldOn 降順でソートされる", async () => {
+    await withRollback(db, async (tx) => {
+      await tx.insert(municipalities).values({
+        code: "462012",
+        name: "鹿児島市",
+        prefecture: "鹿児島県",
+      });
+      await tx.insert(meetings).values([
+        {
+          municipalityCode: "462012",
+          title: "古い会議",
+          meetingType: "定例会",
+          heldOn: "2023-06-01",
+          topicDigests: [
+            { topic: "A", relevance: "primary", digest: "A", speakers: [] },
+            { topic: "B", relevance: "primary", digest: "B", speakers: [] },
+          ],
+        },
+        {
+          municipalityCode: "462012",
+          title: "新しい会議",
+          meetingType: "定例会",
+          heldOn: "2024-06-01",
+          topicDigests: [
+            { topic: "A", relevance: "primary", digest: "A", speakers: [] },
+            { topic: "B", relevance: "primary", digest: "B", speakers: [] },
+          ],
+        },
+      ]);
+
+      const rows = await findMeetingsWithTopics(tx, { topics: ["A", "B"] });
+
+      expect(rows).toHaveLength(2);
+      expect(rows[0]!.title).toBe("新しい会議");
+      expect(rows[1]!.title).toBe("古い会議");
+    });
+  });
+});

--- a/packages/api/src/routers/topics/topics.service.ts
+++ b/packages/api/src/routers/topics/topics.service.ts
@@ -1,0 +1,201 @@
+/**
+ * 議題ベース検索のサービス層。DB の meetings.topic_digests を対象とする。
+ *
+ * Postgres の jsonb_array_elements を使って「topic_digests の中に〇〇にマッチする topic がある meeting」
+ * を効率的に引く。
+ */
+
+import { sql } from "drizzle-orm";
+import type { Db } from "@open-gikai/db";
+import type { MeetingTopicDigest } from "@open-gikai/db/schema";
+
+export type MatchedTopicRow = {
+  meetingId: string;
+  title: string;
+  heldOn: string;
+  meetingType: string;
+  matchedTopic: string;
+  relevance: "primary" | "secondary";
+  digestPreview: string;
+};
+
+/**
+ * topic 名・digest 本文・会議全体サマリのいずれかに query が含まれる meeting を新しい順で返す。
+ *
+ * 返す行は (meeting, 該当 topic) の組。同じ会議に複数ヒットした場合は複数行になる。
+ */
+export async function searchTopics(
+  db: Db,
+  args: {
+    query: string;
+    municipalityCode?: string;
+    dateFrom?: string;
+    dateTo?: string;
+    limit?: number;
+  },
+): Promise<MatchedTopicRow[]> {
+  const limit = args.limit ?? 30;
+  const pattern = `%${args.query}%`;
+  const municipalityClause = args.municipalityCode
+    ? sql`AND m.municipality_code = ${args.municipalityCode}`
+    : sql``;
+  const dateFromClause = args.dateFrom ? sql`AND m.held_on >= ${args.dateFrom}` : sql``;
+  const dateToClause = args.dateTo ? sql`AND m.held_on <= ${args.dateTo}` : sql``;
+
+  const rows = await db.execute<{
+    meeting_id: string;
+    title: string;
+    held_on: string;
+    meeting_type: string;
+    matched_topic: string;
+    relevance: "primary" | "secondary";
+    digest_preview: string;
+  }>(sql`
+    SELECT
+      m.id                                      AS meeting_id,
+      m.title                                   AS title,
+      m.held_on::text                           AS held_on,
+      m.meeting_type                            AS meeting_type,
+      td->>'topic'                              AS matched_topic,
+      (td->>'relevance')::text                  AS relevance,
+      left(td->>'digest', 200)                  AS digest_preview
+    FROM meetings m
+    CROSS JOIN LATERAL jsonb_array_elements(m.topic_digests) td
+    WHERE m.topic_digests IS NOT NULL
+      AND (
+        td->>'topic' ILIKE ${pattern}
+        OR td->>'digest' ILIKE ${pattern}
+        OR m.summary ILIKE ${pattern}
+      )
+      ${municipalityClause}
+      ${dateFromClause}
+      ${dateToClause}
+    ORDER BY m.held_on DESC
+    LIMIT ${limit}
+  `);
+
+  return rows.map((r) => ({
+    meetingId: r.meeting_id,
+    title: r.title,
+    heldOn: r.held_on,
+    meetingType: r.meeting_type,
+    matchedTopic: r.matched_topic,
+    relevance: r.relevance,
+    digestPreview: r.digest_preview,
+  }));
+}
+
+export type MeetingDigest = {
+  meetingId: string;
+  title: string;
+  heldOn: string;
+  meetingType: string;
+  sourceUrl: string | null;
+  summary: string | null;
+  topicDigests: MeetingTopicDigest[];
+};
+
+/**
+ * meeting の全サマリ情報を返す（summary + topic_digests）。
+ */
+export async function getMeetingDigest(db: Db, meetingId: string): Promise<MeetingDigest | null> {
+  const rows = await db.execute<{
+    id: string;
+    title: string;
+    held_on: string;
+    meeting_type: string;
+    source_url: string | null;
+    summary: string | null;
+    topic_digests: MeetingTopicDigest[] | null;
+  }>(sql`
+    SELECT id, title, held_on::text AS held_on, meeting_type, source_url, summary, topic_digests
+    FROM meetings
+    WHERE id = ${meetingId}
+    LIMIT 1
+  `);
+  const r = rows[0];
+  if (!r) return null;
+  return {
+    meetingId: r.id,
+    title: r.title,
+    heldOn: r.held_on,
+    meetingType: r.meeting_type,
+    sourceUrl: r.source_url,
+    summary: r.summary,
+    topicDigests: r.topic_digests ?? [],
+  };
+}
+
+/**
+ * 複数の topic query のすべてにマッチする meeting を返す（関連分析用）。
+ *
+ * 例: ["市バス路線再編", "ICカード"] を渡すと、両方の議論が含まれている会議を返す。
+ */
+export async function findMeetingsWithTopics(
+  db: Db,
+  args: {
+    topics: string[];
+    municipalityCode?: string;
+    limit?: number;
+  },
+): Promise<
+  Array<{
+    meetingId: string;
+    title: string;
+    heldOn: string;
+    meetingType: string;
+    matchedTopicsByQuery: Record<string, string[]>;
+  }>
+> {
+  if (args.topics.length === 0) return [];
+  const limit = args.limit ?? 20;
+
+  // 各 topic query ごとの EXISTS サブクエリを AND 結合
+  const existsClauses = args.topics.map(
+    (q) => sql`EXISTS (
+      SELECT 1 FROM jsonb_array_elements(m.topic_digests) td
+      WHERE td->>'topic' ILIKE ${`%${q}%`} OR td->>'digest' ILIKE ${`%${q}%`}
+    )`,
+  );
+  const existsAnd = sql.join(existsClauses, sql` AND `);
+
+  const municipalityClause = args.municipalityCode
+    ? sql`AND m.municipality_code = ${args.municipalityCode}`
+    : sql``;
+
+  const rows = await db.execute<{
+    id: string;
+    title: string;
+    held_on: string;
+    meeting_type: string;
+    topic_digests: MeetingTopicDigest[];
+  }>(sql`
+    SELECT id, title, held_on::text AS held_on, meeting_type, topic_digests
+    FROM meetings m
+    WHERE topic_digests IS NOT NULL
+      AND ${existsAnd}
+      ${municipalityClause}
+    ORDER BY held_on DESC
+    LIMIT ${limit}
+  `);
+
+  return rows.map((r) => {
+    const matchedTopicsByQuery: Record<string, string[]> = {};
+    for (const q of args.topics) {
+      const lower = q.toLowerCase();
+      matchedTopicsByQuery[q] = r.topic_digests
+        .filter(
+          (td) =>
+            td.topic.toLowerCase().includes(lower) || td.digest.toLowerCase().includes(lower),
+        )
+        .map((td) => td.topic);
+    }
+    return {
+      meetingId: r.id,
+      title: r.title,
+      heldOn: r.held_on,
+      meetingType: r.meeting_type,
+      matchedTopicsByQuery,
+    };
+  });
+}

--- a/packages/api/src/shared/retry.ts
+++ b/packages/api/src/shared/retry.ts
@@ -1,0 +1,40 @@
+/**
+ * Gemini は高負荷時や quota 上限間際で 429 / 503 を返す。
+ * retry-after ヒントがあればそれを優先し、無ければ指数バックオフ。
+ */
+export async function callWithRetry<T>(fn: () => Promise<T>, maxAttempts = 6): Promise<T> {
+  let lastErr: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastErr = err;
+      const msg = err instanceof Error ? err.message : String(err);
+      const retryable = /\b(429|500|502|503|504|UNAVAILABLE|RESOURCE_EXHAUSTED|INTERNAL|ETIMEDOUT|ECONNRESET|ECONNREFUSED|ENOTFOUND|socket hang up)\b/i.test(msg)
+        || /timed?\s*out/i.test(msg)
+        || /timeout/i.test(msg)
+        || /fetch failed/i.test(msg);
+      if (!retryable || attempt === maxAttempts) break;
+
+      // API が retryDelay を返していればそれを使う
+      const retryMs = parseRetryDelayMs(msg) ?? 1000 * Math.pow(2, attempt - 1);
+      const jitter = Math.floor(Math.random() * 500);
+      const delay = retryMs + jitter;
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+  throw lastErr;
+}
+
+/**
+ * Gemini のエラー JSON に含まれる retryDelay (例: "23.634105001s" や "682.756ms") を ms で取り出す。
+ */
+function parseRetryDelayMs(msg: string): number | null {
+  const secMatch = msg.match(/"retryDelay"\s*:\s*"([0-9.]+)s"/);
+  if (secMatch?.[1]) return Math.ceil(parseFloat(secMatch[1]) * 1000);
+  const msMatch = msg.match(/Please retry in ([0-9.]+)ms/);
+  if (msMatch?.[1]) return Math.ceil(parseFloat(msMatch[1]));
+  const sec2Match = msg.match(/Please retry in ([0-9.]+)s/);
+  if (sec2Match?.[1]) return Math.ceil(parseFloat(sec2Match[1]) * 1000);
+  return null;
+}


### PR DESCRIPTION
## Summary

- `apps/meeting-summarizer` の PoC CLI（`ask.ts` / `tools.ts`）のロジックを oRPC プロシージャ化し、apps/web から呼べるようにする
- `topics.search`（議題名・digest・会議サマリ横断の部分一致検索）を追加
- `meetings.ask`（Gemini エージェントループをサーバ側で実行。同期応答で answer + iterations + tokens + tool trace を返す）を追加
- 動作確認用に `/admin/ask` を追加（管理者限定）
- CLI はそのまま維持（次ステップで共通化検討）

## スコープ外（次 worktree）

- `topics.timeline` / `topics.compare` プロシージャ
- トップ（`/`）の議題ブラウズ差し替え、`/topics/:id` / `/topics/compare` の本格 UI
- `meetings.ask` のストリーミング応答
- 認証・レート制限（現状 `publicProcedure`。Gemini コスト発生するため次タスクで検討）

## Test plan

- [ ] `bun run --cwd packages/api test` が green（Supabase ローカル起動要）
- [ ] `bunx tsc --noEmit -p packages/api` / `apps/web` に新規型エラーが出ない
- [ ] `.env.local` に `GEMINI_API_KEY` を入れて `bun run --cwd apps/web dev` → `/admin/ask` で議題検索・質問が動く
- [ ] CLI (`bun run --cwd apps/meeting-summarizer ask -- --municipality 462012 "市バス事業について調べて"`) が引き続き動く

🤖 Generated with [Claude Code](https://claude.com/claude-code)