### PR TITLE
feat: topics.timeline / topics.compare を追加

### DIFF
--- a/apps/web/src/routes/admin/_layout/ask.tsx
+++ b/apps/web/src/routes/admin/_layout/ask.tsx
@@ -25,6 +25,8 @@ function AdminAskPage() {
       <h1 className="text-2xl font-bold">Ask 動作確認</h1>
       <TopicsSearchSection />
       <MeetingsAskSection />
+      <TopicsTimelineSection />
+      <TopicsCompareSection />
     </div>
   );
 }
@@ -211,6 +213,294 @@ function MeetingsAskSection() {
                 ))}
               </CollapsibleContent>
             </Collapsible>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function TopicsTimelineSection() {
+  const [topic, setTopic] = useState("");
+  const [municipalityCode, setMunicipalityCode] = useState("");
+  const [dateFrom, setDateFrom] = useState("");
+  const [dateTo, setDateTo] = useState("");
+
+  const [committedTopic, setCommittedTopic] = useState("");
+  const [committedCode, setCommittedCode] = useState<string | undefined>(undefined);
+  const [committedFrom, setCommittedFrom] = useState<string | undefined>(undefined);
+  const [committedTo, setCommittedTo] = useState<string | undefined>(undefined);
+
+  const enabled = committedTopic.length > 0;
+
+  const { data, isFetching, error } = useQuery({
+    ...orpc.topics.timeline.queryOptions({
+      input: {
+        topic: committedTopic,
+        municipalityCode: committedCode,
+        dateFrom: committedFrom,
+        dateTo: committedTo,
+        limit: 100,
+      },
+    }),
+    enabled,
+  });
+
+  const entries = data?.entries ?? [];
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!topic.trim()) return;
+    setCommittedTopic(topic.trim());
+    setCommittedCode(municipalityCode.trim() || undefined);
+    setCommittedFrom(dateFrom.trim() || undefined);
+    setCommittedTo(dateTo.trim() || undefined);
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>議題タイムライン</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <form onSubmit={onSubmit} className="space-y-3">
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="timeline-topic">議題キーワード</Label>
+            <Input
+              id="timeline-topic"
+              value={topic}
+              onChange={(e) => setTopic(e.target.value)}
+              placeholder="例: 市バス路線再編"
+            />
+          </div>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="timeline-municipality">自治体コード（任意）</Label>
+              <Input
+                id="timeline-municipality"
+                value={municipalityCode}
+                onChange={(e) => setMunicipalityCode(e.target.value)}
+                placeholder="例: 462012"
+              />
+            </div>
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="timeline-from">dateFrom（任意）</Label>
+              <Input
+                id="timeline-from"
+                type="date"
+                value={dateFrom}
+                onChange={(e) => setDateFrom(e.target.value)}
+              />
+            </div>
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="timeline-to">dateTo（任意）</Label>
+              <Input
+                id="timeline-to"
+                type="date"
+                value={dateTo}
+                onChange={(e) => setDateTo(e.target.value)}
+              />
+            </div>
+          </div>
+          <Button type="submit" disabled={!topic.trim()}>
+            タイムライン取得
+          </Button>
+        </form>
+
+        {error && <p className="text-sm text-destructive">エラー: {error.message}</p>}
+
+        {enabled && (
+          <div className="space-y-2">
+            <div className="text-xs text-muted-foreground">
+              {isFetching ? "取得中..." : `${entries.length} 件`}
+            </div>
+            {entries.map((entry) => (
+              <Card key={entry.meetingId} className="border">
+                <CardContent className="py-3 space-y-2 text-sm">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="font-semibold">{entry.heldOn}</span>
+                    <span>
+                      {entry.municipalityName} ({entry.prefecture})
+                    </span>
+                    <span className="text-xs text-muted-foreground">[{entry.meetingType}]</span>
+                  </div>
+                  <div className="font-medium">{entry.title}</div>
+                  {entry.sourceUrl && (
+                    <div>
+                      <a
+                        href={entry.sourceUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="text-xs text-blue-600 underline break-all"
+                      >
+                        {entry.sourceUrl}
+                      </a>
+                    </div>
+                  )}
+                  {entry.matchedTopics.length > 0 && (
+                    <div className="space-y-1">
+                      {entry.matchedTopics.map((mt, idx) => (
+                        <div key={`${entry.meetingId}-${idx}`} className="rounded border p-2">
+                          <div className="text-xs">
+                            <span className="font-medium">{mt.topic}</span>{" "}
+                            <span className="text-muted-foreground">({mt.relevance})</span>
+                          </div>
+                          <div className="text-xs text-muted-foreground whitespace-pre-wrap">
+                            {mt.digest.slice(0, 200)}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                  <div className="text-xs font-mono text-muted-foreground">
+                    meetingId: {entry.meetingId}
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function TopicsCompareSection() {
+  const [topics, setTopics] = useState<string[]>(["", "", ""]);
+  const [municipalityCode, setMunicipalityCode] = useState("");
+
+  const [committedTopics, setCommittedTopics] = useState<string[]>([]);
+  const [committedCode, setCommittedCode] = useState<string | undefined>(undefined);
+
+  const enabled = committedTopics.length >= 2;
+
+  const { data, isFetching, error } = useQuery({
+    ...orpc.topics.compare.queryOptions({
+      input: {
+        // API 側 schema で min(2).max(5)。enabled=false の時は送られない。
+        topics: committedTopics as [string, string, ...string[]],
+        municipalityCode: committedCode,
+        limit: 50,
+      },
+    }),
+    enabled,
+  });
+
+  const rows = data?.rows ?? [];
+
+  const addTopic = () => {
+    if (topics.length >= 5) return;
+    setTopics([...topics, ""]);
+  };
+  const removeTopic = (idx: number) => {
+    if (topics.length <= 2) return;
+    setTopics(topics.filter((_, i) => i !== idx));
+  };
+  const updateTopic = (idx: number, value: string) => {
+    setTopics(topics.map((t, i) => (i === idx ? value : t)));
+  };
+
+  const trimmedNonEmpty = topics.map((t) => t.trim()).filter((t) => t.length > 0);
+  const submitEnabled = trimmedNonEmpty.length >= 2 && trimmedNonEmpty.length <= 5;
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!submitEnabled) return;
+    setCommittedTopics(trimmedNonEmpty);
+    setCommittedCode(municipalityCode.trim() || undefined);
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>議題の関連分析（compare）</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <form onSubmit={onSubmit} className="space-y-3">
+          <div className="space-y-2">
+            <Label>キーワード（2〜5 個）</Label>
+            {topics.map((t, idx) => (
+              <div key={idx} className="flex gap-2">
+                <Input
+                  value={t}
+                  onChange={(e) => updateTopic(idx, e.target.value)}
+                  placeholder={`キーワード ${idx + 1}`}
+                />
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => removeTopic(idx)}
+                  disabled={topics.length <= 2}
+                >
+                  削除
+                </Button>
+              </div>
+            ))}
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={addTopic}
+              disabled={topics.length >= 5}
+            >
+              キーワードを追加
+            </Button>
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="compare-municipality">自治体コード（任意）</Label>
+            <Input
+              id="compare-municipality"
+              value={municipalityCode}
+              onChange={(e) => setMunicipalityCode(e.target.value)}
+              placeholder="例: 462012"
+            />
+          </div>
+          <Button type="submit" disabled={!submitEnabled}>
+            関連会議を検索
+          </Button>
+        </form>
+
+        {error && <p className="text-sm text-destructive">エラー: {error.message}</p>}
+
+        {enabled && (
+          <div className="space-y-2">
+            <div className="text-xs text-muted-foreground">
+              {isFetching ? "検索中..." : `${rows.length} 件ヒット`}
+            </div>
+            {rows.map((row) => (
+              <Card key={row.meetingId} className="border">
+                <CardContent className="py-3 space-y-2 text-sm">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="font-semibold">{row.title}</span>
+                    <span className="text-xs text-muted-foreground">({row.heldOn})</span>
+                    <span className="text-xs text-muted-foreground">[{row.meetingType}]</span>
+                  </div>
+                  <div className="text-xs">
+                    {row.municipalityName} ({row.prefecture}) / code: {row.municipalityCode}
+                  </div>
+                  <div className="space-y-1">
+                    {committedTopics.map((q) => {
+                      const matched = row.matchedTopicsByQuery[q] ?? [];
+                      return (
+                        <div key={`${row.meetingId}-${q}`} className="text-xs">
+                          <span className="font-medium">{q}</span>
+                          <span className="text-muted-foreground"> → </span>
+                          {matched.length === 0 ? (
+                            <span className="text-muted-foreground">(なし)</span>
+                          ) : (
+                            <span>{matched.join(", ")}</span>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                  <div className="text-xs font-mono text-muted-foreground">
+                    meetingId: {row.meetingId}
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
           </div>
         )}
       </CardContent>

--- a/packages/api/src/routers/topics/_schemas/index.ts
+++ b/packages/api/src/routers/topics/_schemas/index.ts
@@ -1,1 +1,3 @@
 export { topicsSearchSchema } from "./topics-search.schema";
+export { topicsTimelineSchema } from "./topics-timeline.schema";
+export { topicsCompareSchema } from "./topics-compare.schema";

--- a/packages/api/src/routers/topics/_schemas/topics-compare.schema.ts
+++ b/packages/api/src/routers/topics/_schemas/topics-compare.schema.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const topicsCompareSchema = z.object({
+  topics: z.array(z.string().min(1)).min(2).max(5),
+  municipalityCode: z.string().optional(),
+  limit: z.number().int().min(1).max(100).default(20),
+});

--- a/packages/api/src/routers/topics/_schemas/topics-timeline.schema.ts
+++ b/packages/api/src/routers/topics/_schemas/topics-timeline.schema.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const topicsTimelineSchema = z.object({
+  topic: z.string().min(1),
+  municipalityCode: z.string().optional(),
+  dateFrom: z.string().optional(),
+  dateTo: z.string().optional(),
+  limit: z.number().int().min(1).max(200).default(100),
+});

--- a/packages/api/src/routers/topics/topics.router.ts
+++ b/packages/api/src/routers/topics/topics.router.ts
@@ -1,11 +1,29 @@
 import { publicProcedure } from "../../index";
-import { topicsSearchSchema } from "./_schemas";
-import { searchTopics } from "./topics.service";
+import {
+  topicsCompareSchema,
+  topicsSearchSchema,
+  topicsTimelineSchema,
+} from "./_schemas";
+import {
+  findMeetingsWithTopics,
+  searchTopics,
+  timelineTopic,
+} from "./topics.service";
 
 export const topicsRouter = {
   search: publicProcedure
     .input(topicsSearchSchema)
     .handler(async ({ input, context }) => ({
       rows: await searchTopics(context.db, input),
+    })),
+  timeline: publicProcedure
+    .input(topicsTimelineSchema)
+    .handler(async ({ input, context }) => ({
+      entries: await timelineTopic(context.db, input),
+    })),
+  compare: publicProcedure
+    .input(topicsCompareSchema)
+    .handler(async ({ input, context }) => ({
+      rows: await findMeetingsWithTopics(context.db, input),
     })),
 };

--- a/packages/api/src/routers/topics/topics.service.test.ts
+++ b/packages/api/src/routers/topics/topics.service.test.ts
@@ -11,6 +11,7 @@ import {
   findMeetingsWithTopics,
   getMeetingDigest,
   searchTopics,
+  timelineTopic,
 } from "./topics.service";
 
 type TestDb = ReturnType<typeof getTestDb>;
@@ -574,6 +575,462 @@ describe("findMeetingsWithTopics", () => {
       expect(rows).toHaveLength(2);
       expect(rows[0]!.title).toBe("新しい会議");
       expect(rows[1]!.title).toBe("古い会議");
+    });
+  });
+
+  it("municipalityCode / municipalityName / prefecture を返す", async () => {
+    await withRollback(db, async (tx) => {
+      await tx.insert(municipalities).values({
+        code: "462012",
+        name: "鹿児島市",
+        prefecture: "鹿児島県",
+      });
+      await tx.insert(meetings).values({
+        municipalityCode: "462012",
+        title: "両方マッチ",
+        meetingType: "定例会",
+        heldOn: "2024-06-01",
+        topicDigests: [
+          { topic: "A", relevance: "primary", digest: "A", speakers: [] },
+          { topic: "B", relevance: "primary", digest: "B", speakers: [] },
+        ],
+      });
+
+      const rows = await findMeetingsWithTopics(tx, { topics: ["A", "B"] });
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.municipalityCode).toBe("462012");
+      expect(rows[0]!.municipalityName).toBe("鹿児島市");
+      expect(rows[0]!.prefecture).toBe("鹿児島県");
+    });
+  });
+});
+
+describe("timelineTopic", () => {
+  it("該当会議を held_on 昇順で返す", async () => {
+    await withRollback(db, async (tx) => {
+      await tx.insert(municipalities).values({
+        code: "462012",
+        name: "鹿児島市",
+        prefecture: "鹿児島県",
+      });
+      await tx.insert(meetings).values([
+        {
+          municipalityCode: "462012",
+          title: "9月会議",
+          meetingType: "定例会",
+          heldOn: "2024-09-01",
+          topicDigests: [
+            {
+              topic: "市バス路線再編",
+              relevance: "primary",
+              digest: "9月の議論",
+              speakers: ["田中議員"],
+            },
+          ],
+        },
+        {
+          municipalityCode: "462012",
+          title: "3月会議",
+          meetingType: "定例会",
+          heldOn: "2024-03-01",
+          topicDigests: [
+            {
+              topic: "市バス路線再編",
+              relevance: "primary",
+              digest: "3月の議論",
+              speakers: ["佐藤議員"],
+            },
+          ],
+        },
+        {
+          municipalityCode: "462012",
+          title: "6月会議",
+          meetingType: "定例会",
+          heldOn: "2024-06-01",
+          topicDigests: [
+            {
+              topic: "市バス路線再編",
+              relevance: "primary",
+              digest: "6月の議論",
+              speakers: ["山本議員"],
+            },
+          ],
+        },
+      ]);
+
+      const entries = await timelineTopic(tx, { topic: "市バス" });
+
+      expect(entries).toHaveLength(3);
+      expect(entries[0]!.title).toBe("3月会議");
+      expect(entries[1]!.title).toBe("6月会議");
+      expect(entries[2]!.title).toBe("9月会議");
+      expect(entries[0]!.municipalityCode).toBe("462012");
+      expect(entries[0]!.municipalityName).toBe("鹿児島市");
+      expect(entries[0]!.prefecture).toBe("鹿児島県");
+      expect(entries[0]!.matchedTopics).toHaveLength(1);
+      expect(entries[0]!.matchedTopics[0]!.topic).toBe("市バス路線再編");
+      expect(entries[0]!.matchedTopics[0]!.relevance).toBe("primary");
+      expect(entries[0]!.matchedTopics[0]!.digest).toBe("3月の議論");
+      expect(entries[0]!.matchedTopics[0]!.speakers).toEqual(["佐藤議員"]);
+    });
+  });
+
+  it("municipalityCode でフィルタできる", async () => {
+    await withRollback(db, async (tx) => {
+      await tx.insert(municipalities).values([
+        { code: "462012", name: "鹿児島市", prefecture: "鹿児島県" },
+        { code: "131001", name: "千代田区", prefecture: "東京都" },
+      ]);
+      await tx.insert(meetings).values([
+        {
+          municipalityCode: "462012",
+          title: "鹿児島の会議",
+          meetingType: "定例会",
+          heldOn: "2024-06-01",
+          topicDigests: [
+            {
+              topic: "観光振興",
+              relevance: "primary",
+              digest: "観光客誘致",
+              speakers: [],
+            },
+          ],
+        },
+        {
+          municipalityCode: "131001",
+          title: "千代田の会議",
+          meetingType: "定例会",
+          heldOn: "2024-06-01",
+          topicDigests: [
+            {
+              topic: "観光振興",
+              relevance: "primary",
+              digest: "観光客誘致",
+              speakers: [],
+            },
+          ],
+        },
+      ]);
+
+      const entries = await timelineTopic(tx, {
+        topic: "観光",
+        municipalityCode: "462012",
+      });
+
+      expect(entries).toHaveLength(1);
+      expect(entries[0]!.title).toBe("鹿児島の会議");
+    });
+  });
+
+  it("dateFrom / dateTo で開催日フィルタ", async () => {
+    await withRollback(db, async (tx) => {
+      await tx.insert(municipalities).values({
+        code: "462012",
+        name: "鹿児島市",
+        prefecture: "鹿児島県",
+      });
+      await tx.insert(meetings).values([
+        {
+          municipalityCode: "462012",
+          title: "2023年の会議",
+          meetingType: "定例会",
+          heldOn: "2023-03-01",
+          topicDigests: [
+            { topic: "防災", relevance: "primary", digest: "防災", speakers: [] },
+          ],
+        },
+        {
+          municipalityCode: "462012",
+          title: "2024年の会議",
+          meetingType: "定例会",
+          heldOn: "2024-06-01",
+          topicDigests: [
+            { topic: "防災", relevance: "primary", digest: "防災", speakers: [] },
+          ],
+        },
+        {
+          municipalityCode: "462012",
+          title: "2025年の会議",
+          meetingType: "定例会",
+          heldOn: "2025-06-01",
+          topicDigests: [
+            { topic: "防災", relevance: "primary", digest: "防災", speakers: [] },
+          ],
+        },
+      ]);
+
+      const entries = await timelineTopic(tx, {
+        topic: "防災",
+        dateFrom: "2024-01-01",
+        dateTo: "2024-12-31",
+      });
+
+      expect(entries).toHaveLength(1);
+      expect(entries[0]!.title).toBe("2024年の会議");
+    });
+  });
+
+  it("1 会議内に同 topic 複数 digest があれば全部返す", async () => {
+    await withRollback(db, async (tx) => {
+      await tx.insert(municipalities).values({
+        code: "462012",
+        name: "鹿児島市",
+        prefecture: "鹿児島県",
+      });
+      await tx.insert(meetings).values({
+        municipalityCode: "462012",
+        title: "防災まみれの会議",
+        meetingType: "定例会",
+        heldOn: "2024-06-01",
+        topicDigests: [
+          {
+            topic: "防災計画",
+            relevance: "primary",
+            digest: "防災計画の見直しについて議論",
+            speakers: ["田中議員"],
+          },
+          {
+            topic: "避難所運営",
+            relevance: "secondary",
+            digest: "防災の観点から避難所運営について",
+            speakers: ["山本議員"],
+          },
+          {
+            topic: "観光振興",
+            relevance: "primary",
+            digest: "観光客誘致",
+            speakers: [],
+          },
+          {
+            topic: "消防団",
+            relevance: "secondary",
+            digest: "消防団員の確保と防災訓練",
+            speakers: ["佐藤議員"],
+          },
+        ],
+      });
+
+      const entries = await timelineTopic(tx, { topic: "防災" });
+
+      expect(entries).toHaveLength(1);
+      expect(entries[0]!.matchedTopics).toHaveLength(3);
+      const matchedTopicNames = entries[0]!.matchedTopics.map((t) => t.topic);
+      expect(matchedTopicNames).toContain("防災計画");
+      expect(matchedTopicNames).toContain("避難所運営");
+      expect(matchedTopicNames).toContain("消防団");
+      expect(matchedTopicNames).not.toContain("観光振興");
+    });
+  });
+
+  it("マッチしない場合は空配列", async () => {
+    await withRollback(db, async (tx) => {
+      await tx.insert(municipalities).values({
+        code: "462012",
+        name: "鹿児島市",
+        prefecture: "鹿児島県",
+      });
+      await tx.insert(meetings).values({
+        municipalityCode: "462012",
+        title: "別件の会議",
+        meetingType: "定例会",
+        heldOn: "2024-06-01",
+        topicDigests: [
+          {
+            topic: "観光振興",
+            relevance: "primary",
+            digest: "観光客誘致",
+            speakers: [],
+          },
+        ],
+      });
+
+      const entries = await timelineTopic(tx, { topic: "存在しない議題" });
+
+      expect(entries).toHaveLength(0);
+    });
+  });
+});
+
+describe("topics.compare (findMeetingsWithTopics wrapper view)", () => {
+  it("2 キーワード両方にヒットする会議を返す", async () => {
+    await withRollback(db, async (tx) => {
+      await tx.insert(municipalities).values({
+        code: "462012",
+        name: "鹿児島市",
+        prefecture: "鹿児島県",
+      });
+      const [matched] = await tx
+        .insert(meetings)
+        .values({
+          municipalityCode: "462012",
+          title: "両方含む会議",
+          meetingType: "定例会",
+          heldOn: "2024-06-01",
+          topicDigests: [
+            {
+              topic: "市バス路線再編",
+              relevance: "primary",
+              digest: "路線の再編",
+              speakers: [],
+            },
+            {
+              topic: "ICカード事業",
+              relevance: "primary",
+              digest: "ICカードの導入",
+              speakers: [],
+            },
+          ],
+        })
+        .returning();
+
+      const rows = await findMeetingsWithTopics(tx, {
+        topics: ["市バス", "ICカード"],
+      });
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.meetingId).toBe(matched!.id);
+      expect(rows[0]!.matchedTopicsByQuery["市バス"]).toEqual([
+        "市バス路線再編",
+      ]);
+      expect(rows[0]!.matchedTopicsByQuery["ICカード"]).toEqual([
+        "ICカード事業",
+      ]);
+    });
+  });
+
+  it("片方しかヒットしない会議は含まれない", async () => {
+    await withRollback(db, async (tx) => {
+      await tx.insert(municipalities).values({
+        code: "462012",
+        name: "鹿児島市",
+        prefecture: "鹿児島県",
+      });
+      await tx.insert(meetings).values({
+        municipalityCode: "462012",
+        title: "片方だけ",
+        meetingType: "定例会",
+        heldOn: "2024-06-01",
+        topicDigests: [
+          {
+            topic: "市バス路線再編",
+            relevance: "primary",
+            digest: "路線の再編",
+            speakers: [],
+          },
+        ],
+      });
+
+      const rows = await findMeetingsWithTopics(tx, {
+        topics: ["市バス", "ICカード"],
+      });
+
+      expect(rows).toHaveLength(0);
+    });
+  });
+
+  it("0 件のときは空配列", async () => {
+    await withRollback(db, async (tx) => {
+      await tx.insert(municipalities).values({
+        code: "462012",
+        name: "鹿児島市",
+        prefecture: "鹿児島県",
+      });
+
+      const rows = await findMeetingsWithTopics(tx, {
+        topics: ["存在しないA", "存在しないB"],
+      });
+
+      expect(rows).toHaveLength(0);
+    });
+  });
+
+  it("municipalityCode フィルタが効く", async () => {
+    await withRollback(db, async (tx) => {
+      await tx.insert(municipalities).values([
+        { code: "462012", name: "鹿児島市", prefecture: "鹿児島県" },
+        { code: "131001", name: "千代田区", prefecture: "東京都" },
+      ]);
+      await tx.insert(meetings).values([
+        {
+          municipalityCode: "462012",
+          title: "鹿児島の会議",
+          meetingType: "定例会",
+          heldOn: "2024-06-01",
+          topicDigests: [
+            { topic: "A議題", relevance: "primary", digest: "A", speakers: [] },
+            { topic: "B議題", relevance: "primary", digest: "B", speakers: [] },
+          ],
+        },
+        {
+          municipalityCode: "131001",
+          title: "千代田の会議",
+          meetingType: "定例会",
+          heldOn: "2024-06-01",
+          topicDigests: [
+            { topic: "A議題", relevance: "primary", digest: "A", speakers: [] },
+            { topic: "B議題", relevance: "primary", digest: "B", speakers: [] },
+          ],
+        },
+      ]);
+
+      const rows = await findMeetingsWithTopics(tx, {
+        topics: ["A議題", "B議題"],
+        municipalityCode: "131001",
+      });
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.title).toBe("千代田の会議");
+      expect(rows[0]!.municipalityCode).toBe("131001");
+      expect(rows[0]!.municipalityName).toBe("千代田区");
+      expect(rows[0]!.prefecture).toBe("東京都");
+    });
+  });
+
+  it("matchedTopicsByQuery は各クエリごとにマッチした topic 名を配列で持つ", async () => {
+    await withRollback(db, async (tx) => {
+      await tx.insert(municipalities).values({
+        code: "462012",
+        name: "鹿児島市",
+        prefecture: "鹿児島県",
+      });
+      await tx.insert(meetings).values({
+        municipalityCode: "462012",
+        title: "複数ヒットの会議",
+        meetingType: "定例会",
+        heldOn: "2024-06-01",
+        topicDigests: [
+          {
+            topic: "防災計画",
+            relevance: "primary",
+            digest: "防災計画",
+            speakers: [],
+          },
+          {
+            topic: "消防団",
+            relevance: "secondary",
+            digest: "消防団員と防災訓練",
+            speakers: [],
+          },
+          {
+            topic: "観光振興",
+            relevance: "primary",
+            digest: "観光客誘致",
+            speakers: [],
+          },
+        ],
+      });
+
+      const rows = await findMeetingsWithTopics(tx, {
+        topics: ["防災", "観光"],
+      });
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.matchedTopicsByQuery["防災"]).toEqual([
+        "防災計画",
+        "消防団",
+      ]);
+      expect(rows[0]!.matchedTopicsByQuery["観光"]).toEqual(["観光振興"]);
     });
   });
 });

--- a/packages/api/src/routers/topics/topics.service.ts
+++ b/packages/api/src/routers/topics/topics.service.ts
@@ -144,6 +144,9 @@ export async function findMeetingsWithTopics(
     title: string;
     heldOn: string;
     meetingType: string;
+    municipalityCode: string;
+    municipalityName: string;
+    prefecture: string;
     matchedTopicsByQuery: Record<string, string[]>;
   }>
 > {
@@ -169,13 +172,25 @@ export async function findMeetingsWithTopics(
     held_on: string;
     meeting_type: string;
     topic_digests: MeetingTopicDigest[];
+    municipality_code: string;
+    municipality_name: string;
+    prefecture: string;
   }>(sql`
-    SELECT id, title, held_on::text AS held_on, meeting_type, topic_digests
+    SELECT
+      m.id                    AS id,
+      m.title                 AS title,
+      m.held_on::text         AS held_on,
+      m.meeting_type          AS meeting_type,
+      m.topic_digests         AS topic_digests,
+      m.municipality_code     AS municipality_code,
+      mu.name                 AS municipality_name,
+      mu.prefecture           AS prefecture
     FROM meetings m
-    WHERE topic_digests IS NOT NULL
+    INNER JOIN municipalities mu ON mu.code = m.municipality_code
+    WHERE m.topic_digests IS NOT NULL
       AND ${existsAnd}
       ${municipalityClause}
-    ORDER BY held_on DESC
+    ORDER BY m.held_on DESC, m.id DESC
     LIMIT ${limit}
   `);
 
@@ -195,7 +210,111 @@ export async function findMeetingsWithTopics(
       title: r.title,
       heldOn: r.held_on,
       meetingType: r.meeting_type,
+      municipalityCode: r.municipality_code,
+      municipalityName: r.municipality_name,
+      prefecture: r.prefecture,
       matchedTopicsByQuery,
     };
   });
+}
+
+export type TimelineMatchedTopic = {
+  topic: string;
+  relevance: "primary" | "secondary";
+  digest: string;
+  speakers: string[];
+};
+
+export type TimelineEntry = {
+  meetingId: string;
+  title: string;
+  heldOn: string;
+  meetingType: string;
+  sourceUrl: string | null;
+  municipalityCode: string;
+  municipalityName: string;
+  prefecture: string;
+  matchedTopics: TimelineMatchedTopic[];
+};
+
+/**
+ * 特定の議題キーワードに関する会議を時系列昇順で返す（UI のタイムライン描画用）。
+ *
+ * matchedTopics は該当会議の topic_digests のうち、topic 名か digest 本文に `topic` が含まれるものだけを抽出する。
+ */
+export async function timelineTopic(
+  db: Db,
+  args: {
+    topic: string;
+    municipalityCode?: string;
+    dateFrom?: string;
+    dateTo?: string;
+    limit?: number;
+  },
+): Promise<TimelineEntry[]> {
+  const limit = args.limit ?? 100;
+  const pattern = `%${args.topic}%`;
+  const municipalityClause = args.municipalityCode
+    ? sql`AND m.municipality_code = ${args.municipalityCode}`
+    : sql``;
+  const dateFromClause = args.dateFrom ? sql`AND m.held_on >= ${args.dateFrom}` : sql``;
+  const dateToClause = args.dateTo ? sql`AND m.held_on <= ${args.dateTo}` : sql``;
+
+  const rows = await db.execute<{
+    meeting_id: string;
+    title: string;
+    held_on: string;
+    meeting_type: string;
+    source_url: string | null;
+    municipality_code: string;
+    municipality_name: string;
+    prefecture: string;
+    topic_digests: MeetingTopicDigest[];
+  }>(sql`
+    SELECT
+      m.id                    AS meeting_id,
+      m.title                 AS title,
+      m.held_on::text         AS held_on,
+      m.meeting_type          AS meeting_type,
+      m.source_url            AS source_url,
+      m.municipality_code     AS municipality_code,
+      mu.name                 AS municipality_name,
+      mu.prefecture           AS prefecture,
+      m.topic_digests         AS topic_digests
+    FROM meetings m
+    INNER JOIN municipalities mu ON mu.code = m.municipality_code
+    WHERE m.topic_digests IS NOT NULL
+      AND EXISTS (
+        SELECT 1 FROM jsonb_array_elements(m.topic_digests) td
+        WHERE td->>'topic' ILIKE ${pattern} OR td->>'digest' ILIKE ${pattern}
+      )
+      ${municipalityClause}
+      ${dateFromClause}
+      ${dateToClause}
+    ORDER BY m.held_on ASC, m.id ASC
+    LIMIT ${limit}
+  `);
+
+  const lower = args.topic.toLowerCase();
+  return rows.map((r) => ({
+    meetingId: r.meeting_id,
+    title: r.title,
+    heldOn: r.held_on,
+    meetingType: r.meeting_type,
+    sourceUrl: r.source_url,
+    municipalityCode: r.municipality_code,
+    municipalityName: r.municipality_name,
+    prefecture: r.prefecture,
+    matchedTopics: r.topic_digests
+      .filter(
+        (td) =>
+          td.topic.toLowerCase().includes(lower) || td.digest.toLowerCase().includes(lower),
+      )
+      .map((td) => ({
+        topic: td.topic,
+        relevance: td.relevance,
+        digest: td.digest,
+        speakers: td.speakers,
+      })),
+  }));
 }


### PR DESCRIPTION
## Summary

- `topics.timeline(topic, municipalityCode?, dateFrom?, dateTo?, limit?)`: 議題キーワードに関する会議を `held_on` 昇順で返す。各会議の該当 matchedTopics（topic名 / relevance / digest / speakers）と自治体情報、sourceUrl を含む。UI のタイムライン描画用。
- `topics.compare(topics[2..5], municipalityCode?, limit?)`: 複数キーワードすべてに言及している会議を返す（関連分析用）。既存 `findMeetingsWithTopics` を municipalities inner join 付きに拡張し、`municipalityCode` / `municipalityName` / `prefecture` を追加。
- `/admin/ask` に両 procedure の動作確認セクションを追加（管理者限定）。

## 先行 PR

- #1144 の続き

## スコープ外（次 worktree）

- トップ `/` の議題ブラウズ差し替え、`/topics/:id` / `/topics/compare` の本 UI
- `meetings.ask` のストリーミング応答
- 認証・レート制限
- `meetings.source_url` 未設定自治体の scraper 改修

## Test plan

- [ ] `bun run --cwd packages/api test`（Supabase ローカル起動要）で timeline / compare テストが green
- [ ] `.env.local` に `GEMINI_API_KEY` を入れて `bun run --cwd apps/web dev` → `/admin/ask` の新セクションでタイムライン取得と関連分析が動く
- [ ] `meetings.ask`（エージェントの find_meetings_with_topics tool）が引き続き動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)