### PR TITLE
feat: 議題ベース探索 UI（トップ差し替え + /topics + /topics/$topic）

### DIFF
--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -10,6 +10,8 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as TopicsIndexRouteImport } from './routes/topics/index'
+import { Route as TopicsTopicRouteImport } from './routes/topics/$topic'
 import { Route as SearchIndexRouteImport } from './routes/search/index'
 import { Route as MeetingsIndexRouteImport } from './routes/meetings/index'
 import { Route as MeetingsMeetingIdRouteImport } from './routes/meetings/$meetingId'
@@ -25,6 +27,16 @@ import { Route as authSignUpOtpIndexRouteImport } from './routes/(auth)/sign-up/
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const TopicsIndexRoute = TopicsIndexRouteImport.update({
+  id: '/topics/',
+  path: '/topics/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const TopicsTopicRoute = TopicsTopicRouteImport.update({
+  id: '/topics/$topic',
+  path: '/topics/$topic',
   getParentRoute: () => rootRouteImport,
 } as any)
 const SearchIndexRoute = SearchIndexRouteImport.update({
@@ -89,6 +101,8 @@ export interface FileRoutesByFullPath {
   '/meetings/$meetingId': typeof MeetingsMeetingIdRoute
   '/meetings/': typeof MeetingsIndexRoute
   '/search/': typeof SearchIndexRoute
+  '/topics/$topic': typeof TopicsTopicRoute
+  '/topics/': typeof TopicsIndexRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/api/rpc/$': typeof ApiRpcSplatRoute
   '/sign-in/': typeof authSignInIndexRoute
@@ -102,6 +116,8 @@ export interface FileRoutesByTo {
   '/meetings/$meetingId': typeof MeetingsMeetingIdRoute
   '/meetings': typeof MeetingsIndexRoute
   '/search': typeof SearchIndexRoute
+  '/topics/$topic': typeof TopicsTopicRoute
+  '/topics': typeof TopicsIndexRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/api/rpc/$': typeof ApiRpcSplatRoute
   '/sign-in': typeof authSignInIndexRoute
@@ -117,6 +133,8 @@ export interface FileRoutesById {
   '/meetings/$meetingId': typeof MeetingsMeetingIdRoute
   '/meetings/': typeof MeetingsIndexRoute
   '/search/': typeof SearchIndexRoute
+  '/topics/$topic': typeof TopicsTopicRoute
+  '/topics/': typeof TopicsIndexRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/api/rpc/$': typeof ApiRpcSplatRoute
   '/(auth)/sign-in/': typeof authSignInIndexRoute
@@ -133,6 +151,8 @@ export interface FileRouteTypes {
     | '/meetings/$meetingId'
     | '/meetings/'
     | '/search/'
+    | '/topics/$topic'
+    | '/topics/'
     | '/api/auth/$'
     | '/api/rpc/$'
     | '/sign-in/'
@@ -146,6 +166,8 @@ export interface FileRouteTypes {
     | '/meetings/$meetingId'
     | '/meetings'
     | '/search'
+    | '/topics/$topic'
+    | '/topics'
     | '/api/auth/$'
     | '/api/rpc/$'
     | '/sign-in'
@@ -160,6 +182,8 @@ export interface FileRouteTypes {
     | '/meetings/$meetingId'
     | '/meetings/'
     | '/search/'
+    | '/topics/$topic'
+    | '/topics/'
     | '/api/auth/$'
     | '/api/rpc/$'
     | '/(auth)/sign-in/'
@@ -175,6 +199,8 @@ export interface RootRouteChildren {
   MeetingsMeetingIdRoute: typeof MeetingsMeetingIdRoute
   MeetingsIndexRoute: typeof MeetingsIndexRoute
   SearchIndexRoute: typeof SearchIndexRoute
+  TopicsTopicRoute: typeof TopicsTopicRoute
+  TopicsIndexRoute: typeof TopicsIndexRoute
   ApiAuthSplatRoute: typeof ApiAuthSplatRoute
   ApiRpcSplatRoute: typeof ApiRpcSplatRoute
   authSignInIndexRoute: typeof authSignInIndexRoute
@@ -196,6 +222,20 @@ declare module '@tanstack/react-router' {
       path: '/search'
       fullPath: '/search/'
       preLoaderRoute: typeof SearchIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/topics/': {
+      id: '/topics/'
+      path: '/topics'
+      fullPath: '/topics/'
+      preLoaderRoute: typeof TopicsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/topics/$topic': {
+      id: '/topics/$topic'
+      path: '/topics/$topic'
+      fullPath: '/topics/$topic'
+      preLoaderRoute: typeof TopicsTopicRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/meetings/': {
@@ -291,6 +331,8 @@ const rootRouteChildren: RootRouteChildren = {
   MeetingsMeetingIdRoute: MeetingsMeetingIdRoute,
   MeetingsIndexRoute: MeetingsIndexRoute,
   SearchIndexRoute: SearchIndexRoute,
+  TopicsTopicRoute: TopicsTopicRoute,
+  TopicsIndexRoute: TopicsIndexRoute,
   ApiAuthSplatRoute: ApiAuthSplatRoute,
   ApiRpcSplatRoute: ApiRpcSplatRoute,
   authSignInIndexRoute: authSignInIndexRoute,

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,7 +1,71 @@
-import { createFileRoute, redirect } from "@tanstack/react-router";
+import { useState } from "react";
+
+import { Link, createFileRoute, useNavigate } from "@tanstack/react-router";
+
+import { Button } from "@/shared/_components/ui/button";
+import { Card, CardContent } from "@/shared/_components/ui/card";
+import { Input } from "@/shared/_components/ui/input";
+import { Label } from "@/shared/_components/ui/label";
 
 export const Route = createFileRoute("/")({
-  beforeLoad: () => {
-    throw redirect({ to: "/search" });
-  },
+  component: LandingPage,
 });
+
+function LandingPage() {
+  const navigate = useNavigate();
+  const [query, setQuery] = useState("");
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = query.trim();
+    if (!trimmed) return;
+    navigate({
+      to: "/topics",
+      search: { q: trimmed },
+    });
+  };
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="mx-auto flex max-w-3xl flex-col gap-8 px-4 py-16">
+        <div className="space-y-3 text-center">
+          <h1 className="text-3xl font-bold sm:text-4xl">議会議事録を議題で探す</h1>
+          <p className="text-sm text-muted-foreground sm:text-base">
+            全国の自治体議会で話し合われた議題から、関連する会議のサマリを横断的に探せます。
+          </p>
+        </div>
+
+        <Card>
+          <CardContent className="p-6">
+            <form onSubmit={onSubmit} className="flex flex-col gap-3">
+              <Label htmlFor="landing-topic-query" className="text-sm">
+                議題キーワード
+              </Label>
+              <div className="flex flex-col gap-2 sm:flex-row">
+                <Input
+                  id="landing-topic-query"
+                  value={query}
+                  onChange={(e) => setQuery(e.target.value)}
+                  placeholder="例: 市バス事業、子ども医療費助成"
+                  className="flex-1"
+                  autoFocus
+                />
+                <Button type="submit" disabled={!query.trim()} className="sm:w-32">
+                  検索
+                </Button>
+              </div>
+            </form>
+          </CardContent>
+        </Card>
+
+        <div className="text-center text-xs text-muted-foreground">
+          発言単位で検索したい場合は{" "}
+          <Link to="/search" className="underline hover:text-foreground">
+            /search
+          </Link>
+          {" "}へ
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/routes/topics/$topic.tsx
+++ b/apps/web/src/routes/topics/$topic.tsx
@@ -1,0 +1,300 @@
+import { useEffect, useState } from "react";
+
+import { useQuery } from "@tanstack/react-query";
+import { Link, createFileRoute, useNavigate } from "@tanstack/react-router";
+import { ChevronLeft } from "lucide-react";
+
+import { orpc } from "@/lib/orpc/orpc";
+import { Badge } from "@/shared/_components/ui/badge";
+import { Button } from "@/shared/_components/ui/button";
+import { Card, CardContent } from "@/shared/_components/ui/card";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/shared/_components/ui/collapsible";
+import { Input } from "@/shared/_components/ui/input";
+import { Label } from "@/shared/_components/ui/label";
+import { Skeleton } from "@/shared/_components/ui/skeleton";
+
+export interface TopicDetailSearchParams {
+  municipalityCode?: string;
+  dateFrom?: string;
+  dateTo?: string;
+}
+
+export const Route = createFileRoute("/topics/$topic")({
+  validateSearch: (search: Record<string, unknown>): TopicDetailSearchParams => ({
+    municipalityCode:
+      typeof search.municipalityCode === "string" ? search.municipalityCode : undefined,
+    dateFrom: typeof search.dateFrom === "string" ? search.dateFrom : undefined,
+    dateTo: typeof search.dateTo === "string" ? search.dateTo : undefined,
+  }),
+  component: TopicDetailPage,
+});
+
+function safeDecode(raw: string): string {
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    return raw;
+  }
+}
+
+function TopicDetailPage() {
+  const { topic: rawTopic } = Route.useParams();
+  const searchParams = Route.useSearch();
+  const navigate = useNavigate();
+
+  const topic = safeDecode(rawTopic);
+
+  const { data, isLoading, isFetching, error } = useQuery({
+    ...orpc.topics.timeline.queryOptions({
+      input: {
+        topic,
+        municipalityCode: searchParams.municipalityCode,
+        dateFrom: searchParams.dateFrom,
+        dateTo: searchParams.dateTo,
+        limit: 100,
+      },
+    }),
+    enabled: topic.length > 0,
+  });
+
+  const entries = data?.entries ?? [];
+
+  const [filterMunicipality, setFilterMunicipality] = useState(searchParams.municipalityCode ?? "");
+  const [filterFrom, setFilterFrom] = useState(searchParams.dateFrom ?? "");
+  const [filterTo, setFilterTo] = useState(searchParams.dateTo ?? "");
+
+  useEffect(() => {
+    setFilterMunicipality(searchParams.municipalityCode ?? "");
+    setFilterFrom(searchParams.dateFrom ?? "");
+    setFilterTo(searchParams.dateTo ?? "");
+  }, [searchParams.municipalityCode, searchParams.dateFrom, searchParams.dateTo]);
+
+  const hasActiveFilters = Boolean(
+    searchParams.municipalityCode || searchParams.dateFrom || searchParams.dateTo,
+  );
+
+  const onApplyFilters = (e: React.FormEvent) => {
+    e.preventDefault();
+    const next: TopicDetailSearchParams = {};
+    if (filterMunicipality.trim()) next.municipalityCode = filterMunicipality.trim();
+    if (filterFrom) next.dateFrom = filterFrom;
+    if (filterTo) next.dateTo = filterTo;
+    navigate({
+      to: "/topics/$topic",
+      params: { topic: rawTopic },
+      search: next,
+    });
+  };
+
+  const onClearFilters = () => {
+    setFilterMunicipality("");
+    setFilterFrom("");
+    setFilterTo("");
+    navigate({
+      to: "/topics/$topic",
+      params: { topic: rawTopic },
+      search: {},
+    });
+  };
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="mx-auto max-w-4xl px-4 py-8 space-y-6">
+        <div>
+          <Link
+            to="/topics"
+            search={{
+              q: topic,
+              municipalityCode: searchParams.municipalityCode,
+              dateFrom: searchParams.dateFrom,
+              dateTo: searchParams.dateTo,
+            }}
+            className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground mb-3"
+          >
+            <ChevronLeft className="h-4 w-4" />
+            議題検索に戻る
+          </Link>
+          <h1 className="text-2xl font-bold leading-snug">{topic}</h1>
+          <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+            {searchParams.municipalityCode && (
+              <Badge variant="secondary">自治体: {searchParams.municipalityCode}</Badge>
+            )}
+            {searchParams.dateFrom && <Badge variant="secondary">from: {searchParams.dateFrom}</Badge>}
+            {searchParams.dateTo && <Badge variant="secondary">to: {searchParams.dateTo}</Badge>}
+            {!hasActiveFilters && <span>フィルタなし（全期間・全自治体）</span>}
+          </div>
+        </div>
+
+        <Collapsible>
+          <CollapsibleTrigger asChild>
+            <Button variant="outline" size="sm">
+              フィルタ変更
+            </Button>
+          </CollapsibleTrigger>
+          <CollapsibleContent className="mt-3">
+            <Card>
+              <CardContent className="p-4">
+                <form onSubmit={onApplyFilters} className="space-y-3">
+                  <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+                    <div className="flex flex-col gap-1.5">
+                      <Label htmlFor="filter-municipality">自治体コード</Label>
+                      <Input
+                        id="filter-municipality"
+                        value={filterMunicipality}
+                        onChange={(e) => setFilterMunicipality(e.target.value)}
+                        placeholder="例: 462012"
+                      />
+                    </div>
+                    <div className="flex flex-col gap-1.5">
+                      <Label htmlFor="filter-from">期間（開始）</Label>
+                      <Input
+                        id="filter-from"
+                        type="date"
+                        value={filterFrom}
+                        onChange={(e) => setFilterFrom(e.target.value)}
+                      />
+                    </div>
+                    <div className="flex flex-col gap-1.5">
+                      <Label htmlFor="filter-to">期間（終了）</Label>
+                      <Input
+                        id="filter-to"
+                        type="date"
+                        value={filterTo}
+                        onChange={(e) => setFilterTo(e.target.value)}
+                      />
+                    </div>
+                  </div>
+                  <div className="flex gap-2">
+                    <Button type="submit" size="sm">
+                      適用
+                    </Button>
+                    <Button type="button" variant="outline" size="sm" onClick={onClearFilters}>
+                      クリア
+                    </Button>
+                  </div>
+                </form>
+              </CardContent>
+            </Card>
+          </CollapsibleContent>
+        </Collapsible>
+
+        {error && (
+          <div className="rounded border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive">
+            エラー: {error.message}
+          </div>
+        )}
+
+        {isLoading && (
+          <div className="space-y-3">
+            {[0, 1, 2].map((i) => (
+              <Card key={i}>
+                <CardContent className="space-y-2 p-4">
+                  <Skeleton className="h-4 w-40" />
+                  <Skeleton className="h-5 w-2/3" />
+                  <Skeleton className="h-3 w-full" />
+                  <Skeleton className="h-3 w-5/6" />
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        )}
+
+        {!isLoading && !error && entries.length === 0 && (
+          <div className="rounded border border-border bg-card p-8 text-center">
+            <p className="text-sm text-muted-foreground">
+              該当する会議が見つかりませんでした
+            </p>
+          </div>
+        )}
+
+        {!isLoading && entries.length > 0 && (
+          <div className="space-y-1">
+            <p className="text-xs text-muted-foreground">
+              {isFetching ? "更新中..." : `${entries.length} 件の会議`}
+            </p>
+            <ol className="relative space-y-4 border-l border-border pl-5">
+              {entries.map((entry) => (
+                <li key={entry.meetingId} className="relative">
+                  <span className="absolute -left-[26px] top-2 h-2.5 w-2.5 rounded-full bg-foreground/70" />
+                  <Card>
+                    <CardContent className="space-y-2 p-4 text-sm">
+                      <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                        <span className="font-semibold text-foreground">{entry.heldOn}</span>
+                        <span>・</span>
+                        <span>
+                          {entry.municipalityName}（{entry.prefecture}）
+                        </span>
+                        <span>・</span>
+                        <span>{entry.meetingType}</span>
+                      </div>
+                      <div className="text-base font-semibold leading-snug">
+                        <Link
+                          to="/meetings/$meetingId"
+                          params={{ meetingId: entry.meetingId }}
+                          className="hover:underline"
+                        >
+                          {entry.title}
+                        </Link>
+                      </div>
+                      {entry.sourceUrl && (
+                        <div>
+                          <a
+                            href={entry.sourceUrl}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="text-xs text-blue-600 underline break-all"
+                          >
+                            原本を開く
+                          </a>
+                        </div>
+                      )}
+                      {entry.matchedTopics.length > 0 && (
+                        <div className="space-y-2 pt-1">
+                          {entry.matchedTopics.map((mt, idx) => (
+                            <div
+                              key={`${entry.meetingId}-${idx}`}
+                              className="rounded border border-border bg-muted/30 p-3"
+                            >
+                              <div className="mb-1 flex flex-wrap items-center gap-2 text-xs">
+                                <span className="font-medium">{mt.topic}</span>
+                                <Badge
+                                  variant={mt.relevance === "primary" ? "default" : "secondary"}
+                                  className="text-[10px]"
+                                >
+                                  {mt.relevance === "primary" ? "主要議題" : "関連議題"}
+                                </Badge>
+                                {mt.speakers.length > 0 && (
+                                  <span className="text-muted-foreground">
+                                    発言者: {mt.speakers.join(", ")}
+                                  </span>
+                                )}
+                              </div>
+                              <p className="line-clamp-6 whitespace-pre-wrap text-xs leading-relaxed text-muted-foreground">
+                                {mt.digest}
+                              </p>
+                            </div>
+                          ))}
+                        </div>
+                      )}
+                    </CardContent>
+                  </Card>
+                </li>
+              ))}
+            </ol>
+          </div>
+        )}
+
+        <div className="border-t border-border pt-4 text-center text-xs text-muted-foreground">
+          この議題の発言を全文検索する →{" "}
+          <Link to="/search" search={{ q: topic }} className="underline hover:text-foreground">
+            /search?q={topic}
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/routes/topics/index.tsx
+++ b/apps/web/src/routes/topics/index.tsx
@@ -1,0 +1,217 @@
+import { useEffect, useState } from "react";
+
+import { useQuery } from "@tanstack/react-query";
+import { Link, createFileRoute, useNavigate } from "@tanstack/react-router";
+
+import { orpc } from "@/lib/orpc/orpc";
+import { Badge } from "@/shared/_components/ui/badge";
+import { Button } from "@/shared/_components/ui/button";
+import { Card, CardContent } from "@/shared/_components/ui/card";
+import { Input } from "@/shared/_components/ui/input";
+import { Label } from "@/shared/_components/ui/label";
+import { Skeleton } from "@/shared/_components/ui/skeleton";
+
+export interface TopicsSearchParams {
+  q?: string;
+  municipalityCode?: string;
+  dateFrom?: string;
+  dateTo?: string;
+}
+
+export const Route = createFileRoute("/topics/")({
+  validateSearch: (search: Record<string, unknown>): TopicsSearchParams => ({
+    q: typeof search.q === "string" ? search.q : undefined,
+    municipalityCode:
+      typeof search.municipalityCode === "string" ? search.municipalityCode : undefined,
+    dateFrom: typeof search.dateFrom === "string" ? search.dateFrom : undefined,
+    dateTo: typeof search.dateTo === "string" ? search.dateTo : undefined,
+  }),
+  component: TopicsSearchPage,
+});
+
+function TopicsSearchPage() {
+  const searchParams = Route.useSearch();
+  const navigate = useNavigate();
+
+  const [query, setQuery] = useState(searchParams.q ?? "");
+  const [municipalityCode, setMunicipalityCode] = useState(searchParams.municipalityCode ?? "");
+  const [dateFrom, setDateFrom] = useState(searchParams.dateFrom ?? "");
+  const [dateTo, setDateTo] = useState(searchParams.dateTo ?? "");
+
+  // Sync local state when URL params change (e.g. browser back/forward, external links)
+  useEffect(() => {
+    setQuery(searchParams.q ?? "");
+    setMunicipalityCode(searchParams.municipalityCode ?? "");
+    setDateFrom(searchParams.dateFrom ?? "");
+    setDateTo(searchParams.dateTo ?? "");
+  }, [searchParams.q, searchParams.municipalityCode, searchParams.dateFrom, searchParams.dateTo]);
+
+  const enabled = Boolean(searchParams.q && searchParams.q.length > 0);
+
+  const { data, isFetching, error } = useQuery({
+    ...orpc.topics.search.queryOptions({
+      input: {
+        query: searchParams.q ?? "",
+        municipalityCode: searchParams.municipalityCode,
+        dateFrom: searchParams.dateFrom,
+        dateTo: searchParams.dateTo,
+        limit: 30,
+      },
+    }),
+    enabled,
+  });
+
+  const rows = data?.rows ?? [];
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = query.trim();
+    if (!trimmed) return;
+    const next: TopicsSearchParams = { q: trimmed };
+    if (municipalityCode.trim()) next.municipalityCode = municipalityCode.trim();
+    if (dateFrom) next.dateFrom = dateFrom;
+    if (dateTo) next.dateTo = dateTo;
+    navigate({ to: "/topics", search: next });
+  };
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="mx-auto max-w-4xl px-4 py-8 space-y-6">
+        <div>
+          <h1 className="text-2xl font-bold mb-1">議題を検索</h1>
+          <p className="text-sm text-muted-foreground">
+            キーワードに一致する議題を含む会議を新しい順で表示します。
+          </p>
+        </div>
+
+        <Card>
+          <CardContent className="p-4">
+            <form onSubmit={onSubmit} className="flex flex-col gap-3">
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="topics-q">キーワード</Label>
+                <div className="flex flex-col gap-2 sm:flex-row">
+                  <Input
+                    id="topics-q"
+                    value={query}
+                    onChange={(e) => setQuery(e.target.value)}
+                    placeholder="例: 市バス事業"
+                    className="flex-1"
+                  />
+                  <Button type="submit" disabled={!query.trim()} className="sm:w-28">
+                    検索
+                  </Button>
+                </div>
+              </div>
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+                <div className="flex flex-col gap-1.5">
+                  <Label htmlFor="topics-municipality">自治体コード（任意）</Label>
+                  <Input
+                    id="topics-municipality"
+                    value={municipalityCode}
+                    onChange={(e) => setMunicipalityCode(e.target.value)}
+                    placeholder="例: 462012"
+                  />
+                </div>
+                <div className="flex flex-col gap-1.5">
+                  <Label htmlFor="topics-date-from">期間（開始・任意）</Label>
+                  <Input
+                    id="topics-date-from"
+                    type="date"
+                    value={dateFrom}
+                    onChange={(e) => setDateFrom(e.target.value)}
+                  />
+                </div>
+                <div className="flex flex-col gap-1.5">
+                  <Label htmlFor="topics-date-to">期間（終了・任意）</Label>
+                  <Input
+                    id="topics-date-to"
+                    type="date"
+                    value={dateTo}
+                    onChange={(e) => setDateTo(e.target.value)}
+                  />
+                </div>
+              </div>
+            </form>
+          </CardContent>
+        </Card>
+
+        {error && (
+          <div className="rounded border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive">
+            エラー: {error.message}
+          </div>
+        )}
+
+        {!enabled && !error && (
+          <div className="rounded border border-border bg-card p-8 text-center">
+            <p className="text-sm text-muted-foreground">キーワードを入力して検索してください</p>
+          </div>
+        )}
+
+        {enabled && isFetching && (
+          <div className="space-y-3">
+            {[0, 1, 2].map((i) => (
+              <Card key={i}>
+                <CardContent className="space-y-2 p-4">
+                  <Skeleton className="h-4 w-32" />
+                  <Skeleton className="h-5 w-2/3" />
+                  <Skeleton className="h-3 w-full" />
+                  <Skeleton className="h-3 w-5/6" />
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        )}
+
+        {enabled && !isFetching && rows.length === 0 && !error && (
+          <div className="rounded border border-border bg-card p-8 text-center">
+            <p className="text-sm text-muted-foreground">該当する議題が見つかりませんでした</p>
+          </div>
+        )}
+
+        {enabled && !isFetching && rows.length > 0 && (
+          <>
+            <p className="text-xs text-muted-foreground">{rows.length} 件の議題</p>
+            <div className="grid gap-3">
+              {rows.map((row) => (
+                <Link
+                  key={`${row.meetingId}-${row.matchedTopic}`}
+                  to="/topics/$topic"
+                  params={{ topic: encodeURIComponent(row.matchedTopic) }}
+                  search={{
+                    municipalityCode: searchParams.municipalityCode,
+                    dateFrom: searchParams.dateFrom,
+                    dateTo: searchParams.dateTo,
+                  }}
+                  className="block"
+                >
+                  <Card className="transition hover:border-foreground/30">
+                    <CardContent className="space-y-2 p-4">
+                      <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                        <span>{row.heldOn}</span>
+                        <span>・</span>
+                        <span>{row.meetingType}</span>
+                        <Badge
+                          variant={row.relevance === "primary" ? "default" : "secondary"}
+                          className="ml-auto"
+                        >
+                          {row.relevance === "primary" ? "主要議題" : "関連議題"}
+                        </Badge>
+                      </div>
+                      <div className="text-base font-semibold leading-snug">
+                        {row.matchedTopic}
+                      </div>
+                      <p className="line-clamp-2 text-sm text-muted-foreground whitespace-pre-wrap">
+                        {row.digestPreview}
+                      </p>
+                      <div className="text-xs text-muted-foreground">{row.title}</div>
+                    </CardContent>
+                  </Card>
+                </Link>
+              ))}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- `/` を `/search` への redirect から、議題キーワード検索の**ランディングページ**に差し替え
- `/topics` に議題キーワード検索ページを新設（`topics.search` を利用）。カードクリックで詳細へ。
- `/topics/$topic` に議題詳細ページを新設（`topics.timeline` を利用）。左縦ラインの時系列表示、sourceUrl リンク、`/search?q=<topic>` への誘導。
- 既存 `/search`（発言単位の検索）は慣れたユーザー向けに残す。`/admin/ask` も残す。

## 先行 PR

- #1144 (meetings.ask + topics.search)
- #1145 (topics.timeline + topics.compare)

## スコープ外（次 worktree）

- `/topics/compare?ids=a,b` の本 UI
- `meetings.ask` のストリーミング応答と UI 組み込み
- 認証・レート制限
- `meetings.source_url` 未設定自治体の scraper 改修
- 自治体絞り込みに `MunicipalitySelector` を接続（今は text 入力）

## Test plan

- [ ] `bun run --cwd apps/web dev` でトップ → 検索 → /topics 結果 → /topics/\$topic タイムラインまで通しで表示できる
- [ ] `routeTree.gen.ts` が dev server 起動時に再生成されても壊れない（等価な内容であること）
- [ ] 既存 `/search` が従来通り動く

🤖 Generated with [Claude Code](https://claude.com/claude-code)