### PR TITLE
feat: /topics 系に MunicipalitySelector を接続

### DIFF
--- a/apps/web/src/routes/topics/$topic.tsx
+++ b/apps/web/src/routes/topics/$topic.tsx
@@ -5,6 +5,7 @@ import { Link, createFileRoute, useNavigate } from "@tanstack/react-router";
 import { ChevronLeft } from "lucide-react";
 
 import { orpc } from "@/lib/orpc/orpc";
+import { MunicipalitySelector } from "@/shared/_components/municipality-selector";
 import { Badge } from "@/shared/_components/ui/badge";
 import { Button } from "@/shared/_components/ui/button";
 import { Card, CardContent } from "@/shared/_components/ui/card";
@@ -63,12 +64,16 @@ function TopicDetailPage() {
 
   const entries = data?.entries ?? [];
 
-  const [filterMunicipality, setFilterMunicipality] = useState(searchParams.municipalityCode ?? "");
+  const [filterMunicipalityCodes, setFilterMunicipalityCodes] = useState<string[]>(
+    searchParams.municipalityCode ? [searchParams.municipalityCode] : [],
+  );
   const [filterFrom, setFilterFrom] = useState(searchParams.dateFrom ?? "");
   const [filterTo, setFilterTo] = useState(searchParams.dateTo ?? "");
 
   useEffect(() => {
-    setFilterMunicipality(searchParams.municipalityCode ?? "");
+    setFilterMunicipalityCodes(
+      searchParams.municipalityCode ? [searchParams.municipalityCode] : [],
+    );
     setFilterFrom(searchParams.dateFrom ?? "");
     setFilterTo(searchParams.dateTo ?? "");
   }, [searchParams.municipalityCode, searchParams.dateFrom, searchParams.dateTo]);
@@ -80,7 +85,8 @@ function TopicDetailPage() {
   const onApplyFilters = (e: React.FormEvent) => {
     e.preventDefault();
     const next: TopicDetailSearchParams = {};
-    if (filterMunicipality.trim()) next.municipalityCode = filterMunicipality.trim();
+    // 複数選択されている場合は先頭のコードのみ API に渡す暫定仕様
+    if (filterMunicipalityCodes.length > 0) next.municipalityCode = filterMunicipalityCodes[0];
     if (filterFrom) next.dateFrom = filterFrom;
     if (filterTo) next.dateTo = filterTo;
     navigate({
@@ -91,7 +97,7 @@ function TopicDetailPage() {
   };
 
   const onClearFilters = () => {
-    setFilterMunicipality("");
+    setFilterMunicipalityCodes([]);
     setFilterFrom("");
     setFilterTo("");
     navigate({
@@ -139,16 +145,16 @@ function TopicDetailPage() {
             <Card>
               <CardContent className="p-4">
                 <form onSubmit={onApplyFilters} className="space-y-3">
-                  <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-                    <div className="flex flex-col gap-1.5">
-                      <Label htmlFor="filter-municipality">自治体コード</Label>
-                      <Input
-                        id="filter-municipality"
-                        value={filterMunicipality}
-                        onChange={(e) => setFilterMunicipality(e.target.value)}
-                        placeholder="例: 462012"
-                      />
-                    </div>
+                  <MunicipalitySelector
+                    selectedCodes={filterMunicipalityCodes}
+                    onChange={setFilterMunicipalityCodes}
+                  />
+                  {filterMunicipalityCodes.length >= 2 && (
+                    <p className="text-xs text-muted-foreground" role="status">
+                      現在の議題検索は 1 自治体のみ対応しています。先頭の自治体のみで検索します。
+                    </p>
+                  )}
+                  <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
                     <div className="flex flex-col gap-1.5">
                       <Label htmlFor="filter-from">期間（開始）</Label>
                       <Input

--- a/apps/web/src/routes/topics/index.tsx
+++ b/apps/web/src/routes/topics/index.tsx
@@ -4,6 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Link, createFileRoute, useNavigate } from "@tanstack/react-router";
 
 import { orpc } from "@/lib/orpc/orpc";
+import { MunicipalitySelector } from "@/shared/_components/municipality-selector";
 import { Badge } from "@/shared/_components/ui/badge";
 import { Button } from "@/shared/_components/ui/button";
 import { Card, CardContent } from "@/shared/_components/ui/card";
@@ -34,14 +35,16 @@ function TopicsSearchPage() {
   const navigate = useNavigate();
 
   const [query, setQuery] = useState(searchParams.q ?? "");
-  const [municipalityCode, setMunicipalityCode] = useState(searchParams.municipalityCode ?? "");
+  const [municipalityCodes, setMunicipalityCodes] = useState<string[]>(
+    searchParams.municipalityCode ? [searchParams.municipalityCode] : [],
+  );
   const [dateFrom, setDateFrom] = useState(searchParams.dateFrom ?? "");
   const [dateTo, setDateTo] = useState(searchParams.dateTo ?? "");
 
   // Sync local state when URL params change (e.g. browser back/forward, external links)
   useEffect(() => {
     setQuery(searchParams.q ?? "");
-    setMunicipalityCode(searchParams.municipalityCode ?? "");
+    setMunicipalityCodes(searchParams.municipalityCode ? [searchParams.municipalityCode] : []);
     setDateFrom(searchParams.dateFrom ?? "");
     setDateTo(searchParams.dateTo ?? "");
   }, [searchParams.q, searchParams.municipalityCode, searchParams.dateFrom, searchParams.dateTo]);
@@ -68,7 +71,8 @@ function TopicsSearchPage() {
     const trimmed = query.trim();
     if (!trimmed) return;
     const next: TopicsSearchParams = { q: trimmed };
-    if (municipalityCode.trim()) next.municipalityCode = municipalityCode.trim();
+    // 複数選択されている場合は先頭のコードのみ API に渡す暫定仕様
+    if (municipalityCodes.length > 0) next.municipalityCode = municipalityCodes[0];
     if (dateFrom) next.dateFrom = dateFrom;
     if (dateTo) next.dateTo = dateTo;
     navigate({ to: "/topics", search: next });
@@ -102,33 +106,35 @@ function TopicsSearchPage() {
                   </Button>
                 </div>
               </div>
-              <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-                <div className="flex flex-col gap-1.5">
-                  <Label htmlFor="topics-municipality">自治体コード（任意）</Label>
-                  <Input
-                    id="topics-municipality"
-                    value={municipalityCode}
-                    onChange={(e) => setMunicipalityCode(e.target.value)}
-                    placeholder="例: 462012"
-                  />
-                </div>
-                <div className="flex flex-col gap-1.5">
-                  <Label htmlFor="topics-date-from">期間（開始・任意）</Label>
-                  <Input
-                    id="topics-date-from"
-                    type="date"
-                    value={dateFrom}
-                    onChange={(e) => setDateFrom(e.target.value)}
-                  />
-                </div>
-                <div className="flex flex-col gap-1.5">
-                  <Label htmlFor="topics-date-to">期間（終了・任意）</Label>
-                  <Input
-                    id="topics-date-to"
-                    type="date"
-                    value={dateTo}
-                    onChange={(e) => setDateTo(e.target.value)}
-                  />
+              <div className="flex flex-col gap-3">
+                <MunicipalitySelector
+                  selectedCodes={municipalityCodes}
+                  onChange={setMunicipalityCodes}
+                />
+                {municipalityCodes.length >= 2 && (
+                  <p className="text-xs text-muted-foreground" role="status">
+                    現在の議題検索は 1 自治体のみ対応しています。先頭の自治体のみで検索します。
+                  </p>
+                )}
+                <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                  <div className="flex flex-col gap-1.5">
+                    <Label htmlFor="topics-date-from">期間（開始・任意）</Label>
+                    <Input
+                      id="topics-date-from"
+                      type="date"
+                      value={dateFrom}
+                      onChange={(e) => setDateFrom(e.target.value)}
+                    />
+                  </div>
+                  <div className="flex flex-col gap-1.5">
+                    <Label htmlFor="topics-date-to">期間（終了・任意）</Label>
+                    <Input
+                      id="topics-date-to"
+                      type="date"
+                      value={dateTo}
+                      onChange={(e) => setDateTo(e.target.value)}
+                    />
+                  </div>
                 </div>
               </div>
             </form>


### PR DESCRIPTION
## Summary

- `/topics` (`apps/web/src/routes/topics/index.tsx`) と `/topics/$topic` (`apps/web/src/routes/topics/$topic.tsx`) の自治体絞り込み UI を、自治体コードの text input から `MunicipalitySelector`（複数選択可のセレクター）に差し替え。
- 既存コンポーネント `apps/web/src/shared/_components/municipality-selector.tsx` をそのまま利用（改修なし）。`/search` と同じ UX に揃う。
- 先行 PR #1147 参照。

## 複数選択時の挙動（暫定）

`topics.search` / `topics.timeline` API は `municipalityCode?: string`（単一 or 未指定）のみ受け付けるため、以下の暫定仕様とする:

- `selectedCodes.length === 0`: 全国検索（`municipalityCode` を `undefined` で送る）
- `selectedCodes.length === 1`: そのコードを送信
- `selectedCodes.length >= 2`: 先頭のコードのみを送信し、UI に「現在の議題検索は 1 自治体のみ対応しています。先頭の自治体のみで検索します。」と注意書きを表示

将来 API が複数自治体対応になったら単純に配列を渡すだけで済む形にしてある。

## Scope

- `apps/web/src/routes/topics/index.tsx`: municipality text input → `MunicipalitySelector`、state を `string[]` 化、URL param 復元/更新を調整
- `apps/web/src/routes/topics/$topic.tsx`: フィルタ Collapsible 内の municipality input を `MunicipalitySelector` に差し替え
- `/`（トップ）には手を入れていない

## Test plan

- [ ] `/topics` を開き、`MunicipalitySelector` から自治体を 1 件選択して検索 → 該当自治体のみ結果が出る
- [ ] 自治体を 0 件選択で検索 → 全国検索として動作
- [ ] 自治体を 2 件以上選択 → 注意書きが出て、先頭の自治体で検索が走る
- [ ] URL の `?municipalityCode=xxx` 直接アクセスで、セレクターに該当自治体が復元される
- [ ] `/topics/$topic` の「フィルタ変更」Collapsible で同様の挙動を確認
- [ ] `bunx tsc --noEmit -p apps/web` で新規型エラーが増えていない

🤖 Generated with [Claude Code](https://claude.com/claude-code)