### PR TITLE
feat: meetings.ask に認証・レート制限・ストリーミングを追加

### DIFF
--- a/apps/web/src/routes/admin/_layout/ask.tsx
+++ b/apps/web/src/routes/admin/_layout/ask.tsx
@@ -1,8 +1,8 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { createFileRoute } from "@tanstack/react-router";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 
-import { orpc } from "@/lib/orpc/orpc";
+import { client, orpc } from "@/lib/orpc/orpc";
 import { Button } from "@/shared/_components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/shared/_components/ui/card";
 import {
@@ -121,19 +121,95 @@ function TopicsSearchSection() {
   );
 }
 
+interface AskProgressEntry {
+  iteration: number;
+  tool: string;
+  args: unknown;
+  resultSummary: string | null;
+}
+
+interface AskFinalResult {
+  answer: string;
+  iterations: number;
+  inputTokens: number;
+  outputTokens: number;
+  trace: { tool: string; args: unknown; resultSummary: string }[];
+}
+
 function MeetingsAskSection() {
   const [municipalityCode, setMunicipalityCode] = useState("");
   const [question, setQuestion] = useState("");
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [progress, setProgress] = useState<AskProgressEntry[]>([]);
+  const [currentIteration, setCurrentIteration] = useState<number | null>(null);
+  const [finalResult, setFinalResult] = useState<AskFinalResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
 
-  const mutation = useMutation(orpc.meetings.ask.mutationOptions());
-
-  const onSubmit = (e: React.FormEvent) => {
+  const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!question.trim()) return;
-    mutation.mutate({
-      question: question.trim(),
-      municipalityCode: municipalityCode.trim() || undefined,
-    });
+    if (!question.trim() || isStreaming) return;
+
+    // 以前のリクエストをキャンセル
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    setIsStreaming(true);
+    setProgress([]);
+    setCurrentIteration(null);
+    setFinalResult(null);
+    setError(null);
+
+    try {
+      const stream = await client.meetings.askStream(
+        {
+          question: question.trim(),
+          municipalityCode: municipalityCode.trim() || undefined,
+        },
+        { signal: controller.signal },
+      );
+
+      for await (const event of stream) {
+        if (event.type === "iteration_start") {
+          setCurrentIteration(event.iteration);
+        } else if (event.type === "tool_call") {
+          setProgress((prev) => [
+            ...prev,
+            {
+              iteration: event.iteration,
+              tool: event.tool,
+              args: event.args,
+              resultSummary: null,
+            },
+          ]);
+        } else if (event.type === "tool_result") {
+          setProgress((prev) => {
+            // 同じ iteration + tool の最後の未確定エントリを更新する
+            const next = [...prev];
+            for (let i = next.length - 1; i >= 0; i--) {
+              const entry = next[i]!;
+              if (
+                entry.iteration === event.iteration &&
+                entry.tool === event.tool &&
+                entry.resultSummary === null
+              ) {
+                next[i] = { ...entry, resultSummary: event.resultSummary };
+                break;
+              }
+            }
+            return next;
+          });
+        } else if (event.type === "done") {
+          setFinalResult(event.result);
+        }
+      }
+    } catch (err) {
+      if (controller.signal.aborted) return;
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setIsStreaming(false);
+    }
   };
 
   return (
@@ -162,21 +238,47 @@ function MeetingsAskSection() {
               rows={5}
             />
           </div>
-          <Button type="submit" disabled={!question.trim() || mutation.isPending}>
-            {mutation.isPending ? "問い合わせ中..." : "聞く"}
+          <Button type="submit" disabled={!question.trim() || isStreaming}>
+            {isStreaming
+              ? `問い合わせ中... (iter ${currentIteration ?? "-"})`
+              : "聞く"}
           </Button>
         </form>
 
-        {mutation.error && (
-          <p className="text-sm text-destructive">エラー: {mutation.error.message}</p>
+        {error && <p className="text-sm text-destructive">エラー: {error}</p>}
+
+        {(isStreaming || progress.length > 0) && (
+          <div className="space-y-2">
+            <div className="text-xs text-muted-foreground">
+              進捗 ({progress.length} 件のツール呼び出し)
+            </div>
+            {progress.map((entry, idx) => (
+              <Card key={idx} className="border">
+                <CardContent className="py-2 space-y-1 text-xs">
+                  <div className="font-semibold">
+                    iter #{entry.iteration} · {entry.tool}
+                  </div>
+                  <div className="font-mono text-muted-foreground break-all">
+                    args: {JSON.stringify(entry.args)}
+                  </div>
+                  <div className="text-muted-foreground">
+                    result:{" "}
+                    {entry.resultSummary ?? (
+                      <span className="italic">実行中...</span>
+                    )}
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
         )}
 
-        {mutation.data && (
+        {finalResult && (
           <div className="space-y-3">
             <div className="flex gap-4 text-xs text-muted-foreground">
-              <span>iterations: {mutation.data.iterations}</span>
-              <span>input tokens: {mutation.data.inputTokens}</span>
-              <span>output tokens: {mutation.data.outputTokens}</span>
+              <span>iterations: {finalResult.iterations}</span>
+              <span>input tokens: {finalResult.inputTokens}</span>
+              <span>output tokens: {finalResult.outputTokens}</span>
             </div>
             <Card className="border">
               <CardHeader className="pb-2">
@@ -184,7 +286,7 @@ function MeetingsAskSection() {
               </CardHeader>
               <CardContent>
                 <pre className="whitespace-pre-wrap text-sm font-sans">
-                  {mutation.data.answer}
+                  {finalResult.answer}
                 </pre>
               </CardContent>
             </Card>
@@ -192,11 +294,11 @@ function MeetingsAskSection() {
             <Collapsible>
               <CollapsibleTrigger asChild>
                 <Button variant="outline" size="sm">
-                  trace を表示 ({mutation.data.trace.length} 件)
+                  trace を表示 ({finalResult.trace.length} 件)
                 </Button>
               </CollapsibleTrigger>
               <CollapsibleContent className="mt-2 space-y-2">
-                {mutation.data.trace.map((t, idx) => (
+                {finalResult.trace.map((t, idx) => (
                   <Card key={idx} className="border">
                     <CardContent className="py-2 space-y-1 text-xs">
                       <div className="font-semibold">

--- a/packages/api/src/routers/meetings/meetings.router.ts
+++ b/packages/api/src/routers/meetings/meetings.router.ts
@@ -1,4 +1,8 @@
-import { publicProcedure } from "../../index";
+import { eventIterator } from "@orpc/server";
+import { z } from "zod";
+
+import { protectedProcedure, publicProcedure } from "../../index";
+import { checkRateLimit } from "../../shared/rate-limit";
 import {
   meetingsAskSchema,
   meetingsListSchema,
@@ -6,9 +10,17 @@ import {
 } from "./_schemas";
 import {
   askMeetings,
+  askMeetingsStream,
   getMeetingStatements,
   listMeetings,
+  type AskMeetingsStreamEvent,
 } from "./meetings.service";
+
+const ASK_RATE_LIMIT = { windowMs: 10 * 60 * 1000, max: 5 } as const;
+
+function enforceAskRateLimit(userId: string): void {
+  checkRateLimit(`meetings.ask:${userId}`, ASK_RATE_LIMIT);
+}
 
 export const meetingsRouter = {
   list: publicProcedure
@@ -19,7 +31,18 @@ export const meetingsRouter = {
     .input(meetingStatementsSchema)
     .handler(({ input, context }) => getMeetingStatements(context.db, input)),
 
-  ask: publicProcedure
+  ask: protectedProcedure
     .input(meetingsAskSchema)
-    .handler(({ input, context }) => askMeetings(context.db, input)),
+    .handler(({ input, context }) => {
+      enforceAskRateLimit(context.session.user.id);
+      return askMeetings(context.db, input);
+    }),
+
+  askStream: protectedProcedure
+    .input(meetingsAskSchema)
+    .output(eventIterator(z.custom<AskMeetingsStreamEvent>()))
+    .handler(async function* ({ input, context }) {
+      enforceAskRateLimit(context.session.user.id);
+      yield* askMeetingsStream(context.db, input);
+    }),
 };

--- a/packages/api/src/routers/meetings/meetings.service.ts
+++ b/packages/api/src/routers/meetings/meetings.service.ts
@@ -256,10 +256,55 @@ export interface AskMeetingsResponse {
   trace: AskMeetingsTraceEntry[];
 }
 
+export type AskMeetingsStreamEvent =
+  | {
+      type: "iteration_start";
+      iteration: number;
+    }
+  | {
+      type: "tool_call";
+      iteration: number;
+      tool: string;
+      args: unknown;
+    }
+  | {
+      type: "tool_result";
+      iteration: number;
+      tool: string;
+      resultSummary: string;
+    }
+  | {
+      type: "final_delta";
+      text: string;
+    }
+  | {
+      type: "done";
+      result: AskMeetingsResponse;
+    };
+
 export async function askMeetings(
   db: Db,
   input: z.input<typeof meetingsAskSchema>,
 ): Promise<AskMeetingsResponse> {
+  // ストリーム実装を最後まで駆動し最終結果だけ返す（非ストリームの互換維持用）
+  let finalResult: AskMeetingsResponse | null = null;
+  for await (const event of askMeetingsStream(db, input)) {
+    if (event.type === "done") {
+      finalResult = event.result;
+    }
+  }
+  if (!finalResult) {
+    throw new ORPCError("INTERNAL_SERVER_ERROR", {
+      message: "askMeetingsStream did not yield a done event",
+    });
+  }
+  return finalResult;
+}
+
+export async function* askMeetingsStream(
+  db: Db,
+  input: z.input<typeof meetingsAskSchema>,
+): AsyncGenerator<AskMeetingsStreamEvent, void, unknown> {
   const apiKey = process.env.GEMINI_API_KEY ?? process.env.GOOGLE_API_KEY;
   if (!apiKey) {
     throw new ORPCError("INTERNAL_SERVER_ERROR", {
@@ -286,6 +331,8 @@ export async function askMeetings(
   let totalOutputTokens = 0;
 
   for (let iter = 0; iter < MAX_ASK_ITERATIONS; iter++) {
+    yield { type: "iteration_start", iteration: iter + 1 };
+
     const response = await callWithRetry(() =>
       client.models.generateContent({
         model,
@@ -312,23 +359,46 @@ export async function askMeetings(
         .map((p) => p.text)
         .filter((t): t is string => Boolean(t))
         .join("");
-      return {
+
+      if (finalText) {
+        yield { type: "final_delta", text: finalText };
+      }
+
+      const result: AskMeetingsResponse = {
         answer: finalText,
         iterations: iter + 1,
         inputTokens: totalInputTokens,
         outputTokens: totalOutputTokens,
         trace,
       };
+      yield { type: "done", result };
+      return;
     }
 
     const functionResponses = [];
     for (const call of functionCalls) {
-      const result = await executeAskFunction(db, input.municipalityCode, call);
-      trace.push({
-        tool: call.name ?? "unknown",
+      const toolName = call.name ?? "unknown";
+      yield {
+        type: "tool_call",
+        iteration: iter + 1,
+        tool: toolName,
         args: call.args ?? {},
-        resultSummary: summarizeAskResult(result),
+      };
+
+      const result = await executeAskFunction(db, input.municipalityCode, call);
+      const resultSummary = summarizeAskResult(result);
+      trace.push({
+        tool: toolName,
+        args: call.args ?? {},
+        resultSummary,
       });
+      yield {
+        type: "tool_result",
+        iteration: iter + 1,
+        tool: toolName,
+        resultSummary,
+      };
+
       functionResponses.push({
         functionResponse: {
           name: call.name,
@@ -339,13 +409,14 @@ export async function askMeetings(
     history.push({ role: "user", parts: functionResponses });
   }
 
-  return {
+  const result: AskMeetingsResponse = {
     answer: "",
     iterations: MAX_ASK_ITERATIONS,
     inputTokens: totalInputTokens,
     outputTokens: totalOutputTokens,
     trace,
   };
+  yield { type: "done", result };
 }
 
 async function executeAskFunction(

--- a/packages/api/src/shared/rate-limit.test.ts
+++ b/packages/api/src/shared/rate-limit.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+import { ORPCError } from "@orpc/server";
+
+import { checkRateLimit } from "./rate-limit";
+
+describe("checkRateLimit", () => {
+  it("上限未満のリクエストは通る", () => {
+    const bucket = new Map<string, number[]>();
+    const now = 1_700_000_000_000;
+
+    const result = checkRateLimit(
+      "ask:user-a",
+      { windowMs: 10 * 60 * 1000, max: 5 },
+      bucket,
+      now,
+    );
+
+    expect(result.remaining).toBe(4);
+    expect(bucket.get("ask:user-a")).toHaveLength(1);
+  });
+
+  it("上限ちょうどまでは通り、超えた瞬間に TOO_MANY_REQUESTS を投げる", () => {
+    const bucket = new Map<string, number[]>();
+    const base = 1_700_000_000_000;
+
+    for (let i = 0; i < 5; i++) {
+      checkRateLimit(
+        "ask:user-a",
+        { windowMs: 10 * 60 * 1000, max: 5 },
+        bucket,
+        base + i,
+      );
+    }
+
+    expect(() =>
+      checkRateLimit(
+        "ask:user-a",
+        { windowMs: 10 * 60 * 1000, max: 5 },
+        bucket,
+        base + 10,
+      ),
+    ).toThrow(ORPCError);
+
+    try {
+      checkRateLimit(
+        "ask:user-a",
+        { windowMs: 10 * 60 * 1000, max: 5 },
+        bucket,
+        base + 10,
+      );
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ORPCError);
+      expect((err as ORPCError<string, unknown>).code).toBe("TOO_MANY_REQUESTS");
+    }
+  });
+
+  it("ウィンドウ外の古いタイムスタンプは捨てられ再度通る", () => {
+    const bucket = new Map<string, number[]>();
+    const base = 1_700_000_000_000;
+    const windowMs = 10 * 60 * 1000;
+
+    // 5 回分を同じ時刻で記録（全て同じウィンドウ内）
+    for (let i = 0; i < 5; i++) {
+      checkRateLimit(
+        "ask:user-a",
+        { windowMs, max: 5 },
+        bucket,
+        base,
+      );
+    }
+
+    // windowMs を完全に超えた時刻なら、古い 5 件はすべて捨てられ再度通る
+    const result = checkRateLimit(
+      "ask:user-a",
+      { windowMs, max: 5 },
+      bucket,
+      base + windowMs + 1,
+    );
+
+    expect(result.remaining).toBe(4);
+    expect(bucket.get("ask:user-a")).toHaveLength(1);
+  });
+
+  it("キーが異なれば独立してカウントされる", () => {
+    const bucket = new Map<string, number[]>();
+    const now = 1_700_000_000_000;
+
+    for (let i = 0; i < 5; i++) {
+      checkRateLimit(
+        "ask:user-a",
+        { windowMs: 10 * 60 * 1000, max: 5 },
+        bucket,
+        now + i,
+      );
+    }
+
+    const result = checkRateLimit(
+      "ask:user-b",
+      { windowMs: 10 * 60 * 1000, max: 5 },
+      bucket,
+      now + 100,
+    );
+
+    expect(result.remaining).toBe(4);
+    expect(bucket.get("ask:user-a")).toHaveLength(5);
+    expect(bucket.get("ask:user-b")).toHaveLength(1);
+  });
+
+  it("TOO_MANY_REQUESTS のエラーに retryAfterMs が含まれる", () => {
+    const bucket = new Map<string, number[]>();
+    const base = 1_700_000_000_000;
+    const windowMs = 10 * 60 * 1000;
+
+    for (let i = 0; i < 5; i++) {
+      checkRateLimit("ask:user-a", { windowMs, max: 5 }, bucket, base + i);
+    }
+
+    try {
+      checkRateLimit("ask:user-a", { windowMs, max: 5 }, bucket, base + 1000);
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ORPCError);
+      const data = (err as ORPCError<string, { retryAfterMs: number; limit: number; windowMs: number }>).data;
+      expect(data.limit).toBe(5);
+      expect(data.windowMs).toBe(10 * 60 * 1000);
+      // base + 0 のタイムスタンプが windowMs + 0 でウィンドウから外れるので、
+      // base + 1000 時点で retryAfterMs は windowMs - 1000 になる
+      expect(data.retryAfterMs).toBe(windowMs - 1000);
+    }
+  });
+
+  it("max が 0 以下なら常に TOO_MANY_REQUESTS", () => {
+    const bucket = new Map<string, number[]>();
+
+    expect(() =>
+      checkRateLimit("ask:user-a", { windowMs: 10_000, max: 0 }, bucket),
+    ).toThrow(ORPCError);
+  });
+});

--- a/packages/api/src/shared/rate-limit.ts
+++ b/packages/api/src/shared/rate-limit.ts
@@ -1,0 +1,71 @@
+import { ORPCError } from "@orpc/server";
+
+export interface RateLimitOptions {
+  windowMs: number;
+  max: number;
+}
+
+type Bucket = Map<string, number[]>;
+
+/**
+ * プロセス内メモリに保持するレート制限用バケット。
+ *
+ * キー構成は呼び出し側責務（`${name}:${userId}` のように衝突を避ける）。
+ * プロセス再起動でリセットされる単純実装で、分散環境での厳密な制限には対応しない。
+ */
+const globalBucket: Bucket = new Map();
+
+/**
+ * `key` が直近 `windowMs` 以内に `max` 回を超えていないか確認する。
+ *
+ * 超えていれば `ORPCError("TOO_MANY_REQUESTS")` を throw する。
+ * 超えていなければ現時刻を記録し、残り回数情報を返す。
+ */
+export function checkRateLimit(
+  key: string,
+  options: RateLimitOptions,
+  bucket: Bucket = globalBucket,
+  now: number = Date.now(),
+): { remaining: number; resetAt: number } {
+  const { windowMs, max } = options;
+  if (max <= 0) {
+    throw new ORPCError("TOO_MANY_REQUESTS", {
+      message: "Rate limit is disabled",
+    });
+  }
+
+  const windowStart = now - windowMs;
+  const prev = bucket.get(key) ?? [];
+  // 古いタイムスタンプを捨てる
+  const recent = prev.filter((t) => t > windowStart);
+
+  if (recent.length >= max) {
+    // 最も古い記録がウィンドウから外れる時刻までリクエストできない
+    const oldest = recent[0]!;
+    const retryAfterMs = Math.max(0, oldest + windowMs - now);
+    const seconds = Math.ceil(retryAfterMs / 1000);
+    throw new ORPCError("TOO_MANY_REQUESTS", {
+      message: `レート上限に達しました。約 ${seconds} 秒後に再試行してください。`,
+      data: {
+        retryAfterMs,
+        limit: max,
+        windowMs,
+      },
+    });
+  }
+
+  recent.push(now);
+  bucket.set(key, recent);
+
+  return {
+    remaining: max - recent.length,
+    resetAt: recent[0]! + windowMs,
+  };
+}
+
+/**
+ * テスト用: グローバルバケットをクリアする。
+ */
+export function __resetRateLimitForTests(): void {
+  globalBucket.clear();
+}


### PR DESCRIPTION
## Summary

先行 PR #1144 で追加した `meetings.ask` を本番運用に耐える形にハードニングする。

- **認証必須化**: `meetings.ask` / 新規 `meetings.askStream` を `protectedProcedure` に変更。ログインユーザーのみ Gemini を叩ける。
- **レート制限**: `packages/api/src/shared/rate-limit.ts` を新設し、ユーザー毎に「10 分あたり 5 リクエスト」を超えたら `ORPCError(\"TOO_MANY_REQUESTS\")` を throw。**インメモリ実装**（`Map<key, number[]>`）でプロセス再起動時にリセットされる割り切り。分散環境での厳密制限は今後の課題。
- **ストリーミング応答（第一希望を採用）**: oRPC の `eventIterator` を使った `meetings.askStream` を追加。エージェントループの各 iteration で `iteration_start` / `tool_call` / `tool_result` / `final_delta` / `done` を yield し、UI 側で進捗表示できるようにした。既存の同期 `meetings.ask` は `askMeetingsStream` を駆動する互換シムとして維持（壊さない）。
- **UI 更新**: `/admin/ask` の `MeetingsAskSection` を `client.meetings.askStream(...)` + `for await` パターンに差し替え、「iter #N · tool名 · args / result」の進捗ログと最終回答を分けて表示。

ストリーミング: **採用（第一希望: oRPC の `eventIterator` / async generator handler）**

## Test plan

- [x] `bunx tsc --noEmit -p packages/api` exit 0
- [x] `bunx tsc --noEmit -p apps/web` 新規エラー 0（既存の admin/_layout/index.tsx・search/_utils/helpers.test.ts のエラーは main から引き継ぎ）
- [x] `bun run --cwd packages/api test` 全 69 tests green（新規 `rate-limit.test.ts` 6 件含む）
- [ ] 手動: ログアウト状態で `/admin/ask` の「聞く」を押すと UNAUTHORIZED になること
- [ ] 手動: ログイン状態で 5 回連続で叩いた後 6 回目が TOO_MANY_REQUESTS になること
- [ ] 手動: ストリーム中に iteration 毎の進捗（tool_call / tool_result）が UI にリアルタイム表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)