### PR TITLE
feat(meeting-summarizer): 発言を NDJSON から読み込むように変更

### DIFF
--- a/apps/meeting-summarizer/AGENTS.md
+++ b/apps/meeting-summarizer/AGENTS.md
@@ -7,11 +7,15 @@ Google Gemini (`@google/genai`) を使って議事録のサマリ生成・議題
 ## 依存
 
 使ってよい:
-- `@open-gikai/db` — meetings / statements テーブルへの読み書き
+
+- `@open-gikai/db` — meetings テーブルへの読み書き（statements テーブルは参照しない）
 - `@google/genai` — LLM 呼び出し
 - `drizzle-orm`
 
+発言本文は DB ではなくローカルの NDJSON (`data/minutes/{year}/{municipalityCode}/statements.ndjson`) から読み込む。`src/read-statements-ndjson.ts` のヘルパー経由で取得する。
+
 使わない:
+
 - `@open-gikai/api`（apps/web 専用）
 - 他の `apps/*`
 

--- a/apps/meeting-summarizer/src/read-statements-ndjson.test.ts
+++ b/apps/meeting-summarizer/src/read-statements-ndjson.test.ts
@@ -1,0 +1,115 @@
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { readStatementsForMeeting } from "./read-statements-ndjson";
+
+describe("readStatementsForMeeting", () => {
+  let dataDir: string;
+
+  beforeEach(async () => {
+    dataDir = await mkdtemp(join(tmpdir(), "stmts-ndjson-"));
+  });
+
+  afterEach(async () => {
+    await rm(dataDir, { recursive: true, force: true });
+  });
+
+  it("heldOn の年ディレクトリから meetingId 一致行のみを startOffset 昇順で返す", async () => {
+    const muniDir = join(dataDir, "2024", "462012");
+    await mkdir(muniDir, { recursive: true });
+    await writeFile(
+      join(muniDir, "statements.ndjson"),
+      [
+        JSON.stringify({
+          id: "s1",
+          meetingId: "m-target",
+          kind: "speech",
+          speakerName: "議員 A",
+          speakerRole: null,
+          content: "発言1",
+          contentHash: "h1",
+          startOffset: 200,
+          endOffset: 250,
+        }),
+        JSON.stringify({
+          id: "s2",
+          meetingId: "m-other",
+          kind: "speech",
+          speakerName: "別会議",
+          speakerRole: null,
+          content: "無関係",
+          contentHash: "h2",
+          startOffset: 0,
+          endOffset: 10,
+        }),
+        JSON.stringify({
+          id: "s3",
+          meetingId: "m-target",
+          kind: "question",
+          speakerName: "議員 B",
+          speakerRole: "議長",
+          content: "発言0",
+          contentHash: "h3",
+          startOffset: 100,
+          endOffset: 150,
+        }),
+      ].join("\n") + "\n",
+    );
+
+    const stmts = await readStatementsForMeeting({
+      dataDir,
+      municipalityCode: "462012",
+      heldOn: "2024-03-15",
+      meetingId: "m-target",
+    });
+
+    expect(stmts.map((s) => s.id)).toEqual(["s3", "s1"]);
+    expect(stmts[0]!.content).toBe("発言0");
+    expect(stmts[1]!.speakerName).toBe("議員 A");
+  });
+
+  it("heldOn の年に無い場合は他の年ディレクトリにフォールバックする", async () => {
+    const other = join(dataDir, "2023", "462012");
+    await mkdir(other, { recursive: true });
+    await writeFile(
+      join(other, "statements.ndjson"),
+      JSON.stringify({
+        id: "s1",
+        meetingId: "m-x",
+        kind: "speech",
+        speakerName: null,
+        speakerRole: null,
+        content: "古い年度",
+        contentHash: "h",
+        startOffset: 0,
+        endOffset: 5,
+      }) + "\n",
+    );
+
+    const stmts = await readStatementsForMeeting({
+      dataDir,
+      municipalityCode: "462012",
+      heldOn: "2024-01-01",
+      meetingId: "m-x",
+    });
+
+    expect(stmts).toHaveLength(1);
+    expect(stmts[0]!.content).toBe("古い年度");
+  });
+
+  it("NDJSON に該当 meetingId が無いときはエラーを投げる", async () => {
+    const muniDir = join(dataDir, "2024", "462012");
+    await mkdir(muniDir, { recursive: true });
+    await writeFile(join(muniDir, "statements.ndjson"), "");
+
+    await expect(
+      readStatementsForMeeting({
+        dataDir,
+        municipalityCode: "462012",
+        heldOn: "2024-03-15",
+        meetingId: "missing",
+      }),
+    ).rejects.toThrow(/statements not found in NDJSON/);
+  });
+});

--- a/apps/meeting-summarizer/src/read-statements-ndjson.ts
+++ b/apps/meeting-summarizer/src/read-statements-ndjson.ts
@@ -1,0 +1,112 @@
+import { createReadStream, existsSync, readdirSync, statSync } from "node:fs";
+import { resolve } from "node:path";
+import { createInterface } from "node:readline";
+
+export type NdjsonStatement = {
+  id: string;
+  meetingId: string;
+  kind: string;
+  speakerName: string | null;
+  speakerRole: string | null;
+  content: string;
+  contentHash: string;
+  startOffset: number | null;
+  endOffset: number | null;
+};
+
+const fileIndexCache = new Map<string, Map<string, NdjsonStatement[]>>();
+
+/**
+ * data/minutes/{year}/{municipalityCode}/statements.ndjson から
+ * 指定 meetingId の発言を読み込む。startOffset 昇順にソートして返す。
+ *
+ * heldOn の年から対象ディレクトリを優先的に探索し、見つからなければ
+ * 同 municipalityCode 配下の全年ディレクトリを探索する。
+ */
+export async function readStatementsForMeeting(params: {
+  dataDir: string;
+  municipalityCode: string;
+  heldOn: string | null;
+  meetingId: string;
+}): Promise<NdjsonStatement[]> {
+  const { dataDir, municipalityCode, heldOn, meetingId } = params;
+  const yearDirs = resolveCandidateYearDirs(dataDir, municipalityCode, heldOn);
+  const searched: string[] = [];
+  for (const dir of yearDirs) {
+    const file = resolve(dir, "statements.ndjson");
+    if (!existsSync(file)) continue;
+    searched.push(file);
+    const index = await loadFileIndex(file);
+    const hits = index.get(meetingId);
+    if (hits && hits.length > 0) {
+      return sortByStartOffset(hits);
+    }
+  }
+  const detail = searched.length > 0 ? ` (searched: ${searched.join(", ")})` : "";
+  throw new Error(
+    `statements not found in NDJSON for meetingId=${meetingId} municipalityCode=${municipalityCode}${detail}`,
+  );
+}
+
+function resolveCandidateYearDirs(
+  dataDir: string,
+  municipalityCode: string,
+  heldOn: string | null,
+): string[] {
+  const seen = new Set<string>();
+  const candidates: string[] = [];
+  const pushIfUnseen = (dir: string) => {
+    if (!seen.has(dir)) {
+      seen.add(dir);
+      candidates.push(dir);
+    }
+  };
+
+  if (heldOn) {
+    const year = heldOn.slice(0, 4);
+    if (/^\d{4}$/.test(year)) {
+      pushIfUnseen(resolve(dataDir, year, municipalityCode));
+    }
+  }
+
+  if (!existsSync(dataDir)) return candidates;
+  for (const entry of readdirSync(dataDir)) {
+    if (!/^\d{4}$/.test(entry)) continue;
+    const dir = resolve(dataDir, entry, municipalityCode);
+    if (existsSync(dir) && statSync(dir).isDirectory()) {
+      pushIfUnseen(dir);
+    }
+  }
+  return candidates;
+}
+
+async function loadFileIndex(file: string): Promise<Map<string, NdjsonStatement[]>> {
+  const cached = fileIndexCache.get(file);
+  if (cached) return cached;
+
+  const index = new Map<string, NdjsonStatement[]>();
+  for await (const line of createInterface({
+    input: createReadStream(file),
+    crlfDelay: Infinity,
+  })) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const row = JSON.parse(trimmed) as NdjsonStatement;
+    const bucket = index.get(row.meetingId);
+    if (bucket) {
+      bucket.push(row);
+    } else {
+      index.set(row.meetingId, [row]);
+    }
+  }
+  fileIndexCache.set(file, index);
+  return index;
+}
+
+function sortByStartOffset(stmts: NdjsonStatement[]): NdjsonStatement[] {
+  return [...stmts].sort((a, b) => {
+    const ao = a.startOffset ?? Number.POSITIVE_INFINITY;
+    const bo = b.startOffset ?? Number.POSITIVE_INFINITY;
+    return ao - bo;
+  });
+}

--- a/apps/meeting-summarizer/src/summarize-batch.ts
+++ b/apps/meeting-summarizer/src/summarize-batch.ts
@@ -27,6 +27,8 @@ import { DEFAULT_MODEL, summarizeMeeting } from "./summarize";
 const root = resolve(fileURLToPath(import.meta.url), "../../../../");
 dotenv.config({ path: resolve(root, ".env.local"), override: true });
 
+const dataDir = resolve(root, "data/minutes");
+
 type Args = {
   municipality: string;
   concurrency: number;
@@ -49,7 +51,9 @@ async function main() {
 
   const targets = await loadTargets(db, args);
   console.error(`[batch] target meetings: ${targets.length}`);
-  console.error(`[batch] municipality=${args.municipality} concurrency=${args.concurrency} model=${args.model}`);
+  console.error(
+    `[batch] municipality=${args.municipality} concurrency=${args.concurrency} model=${args.model}`,
+  );
   if (args.dryRun) {
     console.error(`[batch] dry-run — no LLM calls, no writes`);
     return;
@@ -73,7 +77,7 @@ async function main() {
       const m = targets[idx]!;
       const label = `[${idx + 1}/${targets.length}] ${m.heldOn} ${m.title.slice(0, 40)}`;
       try {
-        const result = await summarizeMeeting(db, m.id, client, args.model);
+        const result = await summarizeMeeting(db, m.id, client, dataDir, args.model);
         await db
           .update(meetings)
           .set({
@@ -105,7 +109,9 @@ async function main() {
   console.error("");
   console.error(`[batch] finished in ${elapsed.toFixed(1)}s`);
   console.error(`  done=${stats.done}  failed=${stats.failed}`);
-  console.error(`  tokens: prompt=${stats.totalPromptTokens}  thoughts=${stats.totalThoughtsTokens}  output=${stats.totalOutputTokens}`);
+  console.error(
+    `  tokens: prompt=${stats.totalPromptTokens}  thoughts=${stats.totalThoughtsTokens}  output=${stats.totalOutputTokens}`,
+  );
 
   // Gemini 2.5 Flash 料金（2026-04 時点）: input $0.30/M, output+thoughts $2.50/M
   const inputCost = (stats.totalPromptTokens / 1_000_000) * 0.3;

--- a/apps/meeting-summarizer/src/summarize-one.ts
+++ b/apps/meeting-summarizer/src/summarize-one.ts
@@ -27,6 +27,8 @@ import { DEFAULT_MODEL, summarizeMeeting } from "./summarize";
 const root = resolve(fileURLToPath(import.meta.url), "../../../../");
 dotenv.config({ path: resolve(root, ".env.local"), override: true });
 
+const dataDir = resolve(root, "data/minutes");
+
 const KAGOSHIMA = "462012";
 
 async function main() {
@@ -54,7 +56,7 @@ async function main() {
   console.error(`  model: ${model}`);
 
   const startedAt = Date.now();
-  const result = await summarizeMeeting(db, meetingId, client, model);
+  const result = await summarizeMeeting(db, meetingId, client, dataDir, model);
   const elapsed = Date.now() - startedAt;
 
   console.error("");
@@ -64,7 +66,9 @@ async function main() {
   console.error(`  candidate_tokens: ${result.usage.candidateTokens}`);
   console.error(`  total_tokens: ${result.usage.totalTokens}`);
 
-  console.log(JSON.stringify({ summary: result.summary, topic_digests: result.topicDigests }, null, 2));
+  console.log(
+    JSON.stringify({ summary: result.summary, topic_digests: result.topicDigests }, null, 2),
+  );
 
   if (args.write) {
     await db

--- a/apps/meeting-summarizer/src/summarize.ts
+++ b/apps/meeting-summarizer/src/summarize.ts
@@ -1,8 +1,9 @@
 import { GoogleGenAI, Type } from "@google/genai";
-import { eq, asc } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import type { Db } from "@open-gikai/db";
-import { meetings, statements, type MeetingTopicDigest } from "@open-gikai/db/schema";
+import { meetings, type MeetingTopicDigest } from "@open-gikai/db/schema";
 import { SYSTEM_PROMPT } from "./prompt";
+import { readStatementsForMeeting } from "./read-statements-ndjson";
 import { callWithRetry } from "./retry";
 
 export const DEFAULT_MODEL = "gemini-2.5-flash";
@@ -44,12 +45,15 @@ const RESPONSE_SCHEMA = {
 
 /**
  * 指定 meeting の全発言を 1 回の LLM 呼び出しでサマリ化する。
+ * 発言本文はローカルの NDJSON (`{dataDir}/{year}/{municipalityCode}/statements.ndjson`)
+ * から読み込む（statements テーブルは参照しない）。
  * 戻り値を返すだけで DB 書き込みは呼び出し側の責務。
  */
 export async function summarizeMeeting(
   db: Db,
   meetingId: string,
   client: GoogleGenAI,
+  dataDir: string,
   model: string = DEFAULT_MODEL,
 ): Promise<SummarizeResult> {
   const meeting = await db.query.meetings.findFirst({
@@ -57,9 +61,11 @@ export async function summarizeMeeting(
   });
   if (!meeting) throw new Error(`meeting not found: ${meetingId}`);
 
-  const stmts = await db.query.statements.findMany({
-    where: eq(statements.meetingId, meetingId),
-    orderBy: [asc(statements.startOffset)],
+  const stmts = await readStatementsForMeeting({
+    dataDir,
+    municipalityCode: meeting.municipalityCode,
+    heldOn: meeting.heldOn,
+    meetingId,
   });
 
   const transcript = stmts


### PR DESCRIPTION
## Summary
- `statements` テーブル廃止に備えて、`summarizeMeeting` が `data/minutes/{year}/{municipalityCode}/statements.ndjson` から発言を読み込むように差し替え
- `meetings` テーブルは引き続き参照（municipalityCode / heldOn を利用して年ディレクトリを解決）
- NDJSON リーダーはファイル単位でメモリ上にインデックス化してキャッシュ。heldOn の年を優先し、見つからなければ同自治体の全年ディレクトリを走査

## Test plan
- [x] `bun run --cwd apps/meeting-summarizer test` — 新規 `read-statements-ndjson.test.ts` 含め全パス
- [x] `bun run --cwd apps/meeting-summarizer check-types` — パス
- [x] `bun run agent:check` — 全タスク成功
- [ ] 実データで `bun run summarize:one -- --kagoshima-sample` を実行して動作確認（要 `data/minutes` / DB / Gemini キー）

🤖 Generated with [Claude Code](https://claude.com/claude-code)