### PR TITLE
feat(meeting-summarizer): サマリ結果を NDJSON 経由で本番 DB に反映

### DIFF
--- a/apps/meeting-summarizer/AGENTS.md
+++ b/apps/meeting-summarizer/AGENTS.md
@@ -8,11 +8,13 @@ Google Gemini (`@google/genai`) を使って議事録のサマリ生成・議題
 
 使ってよい:
 
-- `@open-gikai/db` — meetings テーブルへの読み書き（statements テーブルは参照しない）
+- `@open-gikai/db` — meetings テーブルの **読み取り** と型定義（statements テーブルは参照しない）
 - `@google/genai` — LLM 呼び出し
 - `drizzle-orm`
 
 発言本文は DB ではなくローカルの NDJSON (`data/minutes/{year}/{municipalityCode}/statements.ndjson`) から読み込む。`src/read-statements-ndjson.ts` のヘルパー経由で取得する。
+
+サマリ結果は **DB に直接書かず**、ローカル NDJSON (`data/minutes/{year}/{municipalityCode}/summaries.ndjson`) に追記する。`src/write-summary-ndjson.ts` の `appendSummaryRow()` を使う。本番 DB への反映は `packages/db` の `db:import:summaries` / `db:import:summaries:prd` で行う。
 
 使わない:
 
@@ -25,6 +27,7 @@ Google Gemini (`@google/genai`) を使って議事録のサマリ生成・議題
 - `src/summarize-batch.ts` — バッチサマリ (`summarize:batch`)
 - `src/ask.ts` — エージェント検索 PoC (`ask`)
 - `src/summarize.ts`, `src/prompt.ts`, `src/tools.ts`, `src/retry.ts` — 共有モジュール
+- `src/write-summary-ndjson.ts` — サマリ結果を summaries.ndjson に追記
 
 ## 開発
 

--- a/apps/meeting-summarizer/src/summarize-batch.ts
+++ b/apps/meeting-summarizer/src/summarize-batch.ts
@@ -6,13 +6,15 @@
  *   bun run summarize:batch -- --municipality 462012 --concurrency 5
  *   bun run summarize:batch -- --municipality 462012 --limit 10     # 先頭 10 件だけ
  *   bun run summarize:batch -- --municipality 462012 --skip-existing # 既にサマリある会議はスキップ
- *   bun run summarize:batch -- --municipality 462012 --dry-run       # DB に書かず件数だけ確認
+ *   bun run summarize:batch -- --municipality 462012 --dry-run       # LLM 呼ばずに件数だけ確認
  *
  * 基本方針:
  * - 自治体内の meetings を held_on 昇順で処理
  * - 並列度は --concurrency（デフォルト 3）
  * - 1 件失敗しても他を続ける（エラーは stderr に記録）
- * - 各件ごとにコミット（中断しても再開しやすい）
+ * - 各件ごとに data/minutes/{year}/{municipalityCode}/summaries.ndjson に追記
+ * - --skip-existing は DB の meetings.summary を参照する（NDJSON 重複は import 側で「最後の行が勝つ」）
+ * - 本番 DB への反映は packages/db の `db:import:summaries:prd` で行う
  */
 
 import { resolve } from "node:path";
@@ -23,6 +25,7 @@ import { and, asc, eq, isNull } from "drizzle-orm";
 import { createDb, type Db } from "@open-gikai/db";
 import { meetings } from "@open-gikai/db/schema";
 import { DEFAULT_MODEL, summarizeMeeting } from "./summarize";
+import { appendSummaryRow } from "./write-summary-ndjson";
 
 const root = resolve(fileURLToPath(import.meta.url), "../../../../");
 dotenv.config({ path: resolve(root, ".env.local"), override: true });
@@ -78,15 +81,15 @@ async function main() {
       const label = `[${idx + 1}/${targets.length}] ${m.heldOn} ${m.title.slice(0, 40)}`;
       try {
         const result = await summarizeMeeting(db, m.id, client, dataDir, args.model);
-        await db
-          .update(meetings)
-          .set({
-            summary: result.summary,
-            topicDigests: result.topicDigests,
-            summaryGeneratedAt: new Date(),
-            summaryModel: args.model,
-          })
-          .where(eq(meetings.id, m.id));
+        await appendSummaryRow(dataDir, {
+          meetingId: m.id,
+          municipalityCode: m.municipalityCode,
+          heldOn: m.heldOn,
+          summary: result.summary,
+          topicDigests: result.topicDigests,
+          summaryModel: args.model,
+          summaryGeneratedAt: new Date().toISOString(),
+        });
         stats.done++;
         stats.totalPromptTokens += result.usage.promptTokens;
         stats.totalOutputTokens += result.usage.candidateTokens;
@@ -126,7 +129,7 @@ async function loadTargets(db: Db, args: Args) {
   const rows = await db.query.meetings.findMany({
     where,
     orderBy: [asc(meetings.heldOn), asc(meetings.id)],
-    columns: { id: true, title: true, heldOn: true },
+    columns: { id: true, title: true, heldOn: true, municipalityCode: true },
     limit: args.limit,
   });
   return rows;

--- a/apps/meeting-summarizer/src/summarize-one.ts
+++ b/apps/meeting-summarizer/src/summarize-one.ts
@@ -8,11 +8,14 @@
  *   # 鹿児島市の直近 plenary を自動選択
  *   bun run summarize:one -- --kagoshima-sample
  *
- *   # DB に書き込む場合は --write を付ける（デフォルトは dry-run）
- *   bun run summarize:one -- --kagoshima-sample --write
+ *   # サマリを NDJSON に書かず stdout 出力だけする場合
+ *   bun run summarize:one -- --kagoshima-sample --dry-run
  *
  *   # モデルを切り替え
  *   bun run summarize:one -- --kagoshima-sample --model gemini-2.5-pro
+ *
+ * サマリ結果は data/minutes/{year}/{municipalityCode}/summaries.ndjson に追記される。
+ * 本番 DB への反映は packages/db の `db:import:summaries:prd` スクリプトで行う。
  */
 
 import { resolve } from "node:path";
@@ -23,6 +26,7 @@ import { and, desc, eq } from "drizzle-orm";
 import { createDb } from "@open-gikai/db";
 import { meetings } from "@open-gikai/db/schema";
 import { DEFAULT_MODEL, summarizeMeeting } from "./summarize";
+import { appendSummaryRow } from "./write-summary-ndjson";
 
 const root = resolve(fileURLToPath(import.meta.url), "../../../../");
 dotenv.config({ path: resolve(root, ".env.local"), override: true });
@@ -70,20 +74,23 @@ async function main() {
     JSON.stringify({ summary: result.summary, topic_digests: result.topicDigests }, null, 2),
   );
 
-  if (args.write) {
-    await db
-      .update(meetings)
-      .set({
-        summary: result.summary,
-        topicDigests: result.topicDigests,
-        summaryGeneratedAt: new Date(),
-        summaryModel: model,
-      })
-      .where(eq(meetings.id, meetingId));
-    console.error(`[meeting-summarizer] wrote to DB`);
-  } else {
-    console.error(`[meeting-summarizer] dry-run (pass --write to persist)`);
+  if (args.dryRun) {
+    console.error(`[meeting-summarizer] dry-run — not writing NDJSON`);
+    return;
   }
+
+  await appendSummaryRow(dataDir, {
+    meetingId,
+    municipalityCode: meeting.municipalityCode,
+    heldOn: meeting.heldOn,
+    summary: result.summary,
+    topicDigests: result.topicDigests,
+    summaryModel: model,
+    summaryGeneratedAt: new Date().toISOString(),
+  });
+  console.error(
+    `[meeting-summarizer] wrote summary to data/minutes/${meeting.heldOn.slice(0, 4)}/${meeting.municipalityCode}/summaries.ndjson`,
+  );
 }
 
 async function pickKagoshimaSample(db: ReturnType<typeof createDb>): Promise<string> {
@@ -95,23 +102,23 @@ async function pickKagoshimaSample(db: ReturnType<typeof createDb>): Promise<str
   return m.id;
 }
 
-function parseArgs(argv: string[]): { meetingId?: string; write: boolean; model?: string } {
+function parseArgs(argv: string[]): { meetingId?: string; dryRun: boolean; model?: string } {
   let meetingId: string | undefined;
-  let write = false;
+  let dryRun = false;
   let model: string | undefined;
   let useSample = false;
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === "--meeting-id") meetingId = argv[++i];
     else if (a === "--kagoshima-sample") useSample = true;
-    else if (a === "--write") write = true;
+    else if (a === "--dry-run") dryRun = true;
     else if (a === "--model") model = argv[++i];
     else throw new Error(`unknown arg: ${a}`);
   }
   if (!meetingId && !useSample) {
     throw new Error("pass --meeting-id <id> or --kagoshima-sample");
   }
-  return { meetingId, write, model };
+  return { meetingId, dryRun, model };
 }
 
 main()

--- a/apps/meeting-summarizer/src/write-summary-ndjson.test.ts
+++ b/apps/meeting-summarizer/src/write-summary-ndjson.test.ts
@@ -1,0 +1,103 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { appendSummaryRow } from "./write-summary-ndjson";
+
+describe("appendSummaryRow", () => {
+  let dataDir: string;
+
+  beforeEach(async () => {
+    dataDir = await mkdtemp(join(tmpdir(), "summaries-ndjson-"));
+  });
+
+  afterEach(async () => {
+    await rm(dataDir, { recursive: true, force: true });
+  });
+
+  it("heldOn の年/自治体コードのディレクトリに summaries.ndjson を追記する", async () => {
+    await appendSummaryRow(dataDir, {
+      meetingId: "m-1",
+      municipalityCode: "462012",
+      heldOn: "2024-03-15",
+      summary: "本会議のサマリ",
+      topicDigests: [
+        { topic: "予算", relevance: "primary", digest: "予算審議の要点", speakers: ["議員 A"] },
+      ],
+      summaryModel: "gemini-2.5-flash",
+      summaryGeneratedAt: "2026-04-19T10:00:00.000Z",
+    });
+
+    const content = await readFile(join(dataDir, "2024", "462012", "summaries.ndjson"), "utf-8");
+    const lines = content.trim().split("\n");
+    expect(lines).toHaveLength(1);
+    const parsed = JSON.parse(lines[0]!);
+    expect(parsed.meetingId).toBe("m-1");
+    expect(parsed.summary).toBe("本会議のサマリ");
+    expect(parsed.topicDigests).toEqual([
+      { topic: "予算", relevance: "primary", digest: "予算審議の要点", speakers: ["議員 A"] },
+    ]);
+    expect(parsed.summaryModel).toBe("gemini-2.5-flash");
+  });
+
+  it("複数回呼んでも append されて行が積み上がる", async () => {
+    await appendSummaryRow(dataDir, {
+      meetingId: "m-1",
+      municipalityCode: "462012",
+      heldOn: "2024-03-15",
+      summary: "1 回目",
+      topicDigests: [],
+      summaryModel: "gemini-2.5-flash",
+      summaryGeneratedAt: "2026-04-19T10:00:00.000Z",
+    });
+    await appendSummaryRow(dataDir, {
+      meetingId: "m-1",
+      municipalityCode: "462012",
+      heldOn: "2024-03-15",
+      summary: "2 回目",
+      topicDigests: [],
+      summaryModel: "gemini-2.5-pro",
+      summaryGeneratedAt: "2026-04-19T11:00:00.000Z",
+    });
+
+    const content = await readFile(join(dataDir, "2024", "462012", "summaries.ndjson"), "utf-8");
+    const lines = content.trim().split("\n");
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0]!).summary).toBe("1 回目");
+    expect(JSON.parse(lines[1]!).summary).toBe("2 回目");
+  });
+
+  it("並列で大量に append しても行が壊れず全部入る", async () => {
+    const rows = Array.from({ length: 50 }, (_, i) => ({
+      meetingId: `m-${i}`,
+      municipalityCode: "462012",
+      heldOn: "2024-03-15",
+      summary: `summary ${i}`.repeat(20),
+      topicDigests: [],
+      summaryModel: "gemini-2.5-flash",
+      summaryGeneratedAt: "2026-04-19T10:00:00.000Z",
+    }));
+
+    await Promise.all(rows.map((r) => appendSummaryRow(dataDir, r)));
+
+    const content = await readFile(join(dataDir, "2024", "462012", "summaries.ndjson"), "utf-8");
+    const lines = content.trim().split("\n");
+    expect(lines).toHaveLength(50);
+    const ids = new Set(lines.map((l) => JSON.parse(l).meetingId));
+    expect(ids.size).toBe(50);
+  });
+
+  it("heldOn が 4 桁年で始まらない場合はエラー", async () => {
+    await expect(
+      appendSummaryRow(dataDir, {
+        meetingId: "m-bad",
+        municipalityCode: "462012",
+        heldOn: "invalid-date",
+        summary: "x",
+        topicDigests: [],
+        summaryModel: "gemini-2.5-flash",
+        summaryGeneratedAt: "2026-04-19T10:00:00.000Z",
+      }),
+    ).rejects.toThrow(/invalid heldOn/);
+  });
+});

--- a/apps/meeting-summarizer/src/write-summary-ndjson.ts
+++ b/apps/meeting-summarizer/src/write-summary-ndjson.ts
@@ -1,0 +1,38 @@
+import { mkdir, appendFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import type { MeetingTopicDigest } from "@open-gikai/db/schema";
+
+export type SummaryNdjsonRow = {
+  meetingId: string;
+  municipalityCode: string;
+  heldOn: string;
+  summary: string;
+  topicDigests: MeetingTopicDigest[];
+  summaryModel: string;
+  summaryGeneratedAt: string;
+};
+
+let writeChain: Promise<void> = Promise.resolve();
+
+/**
+ * data/minutes/{year}/{municipalityCode}/summaries.ndjson に 1 行追記する。
+ *
+ * 並列 worker から呼ばれても行が壊れないよう、モジュールレベルで
+ * Promise チェーンによる直列化を行う。
+ */
+export function appendSummaryRow(dataDir: string, row: SummaryNdjsonRow): Promise<void> {
+  const year = row.heldOn.slice(0, 4);
+  if (!/^\d{4}$/.test(year)) {
+    return Promise.reject(new Error(`invalid heldOn for year extraction: ${row.heldOn}`));
+  }
+  const dir = resolve(dataDir, year, row.municipalityCode);
+  const file = resolve(dir, "summaries.ndjson");
+  const line = JSON.stringify(row) + "\n";
+
+  const next = writeChain.then(async () => {
+    await mkdir(dir, { recursive: true });
+    await appendFile(file, line, "utf-8");
+  });
+  writeChain = next.catch(() => undefined);
+  return next;
+}

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -23,6 +23,8 @@
     "db:migrate": "drizzle-kit migrate",
     "db:import": "bun run seeds/insert-to-pgsql.ts",
     "db:import:prd": "bun run seeds/insert-to-pgsql-prd.ts",
+    "db:import:summaries": "bun run seeds/insert-summaries-to-pgsql.ts",
+    "db:import:summaries:prd": "bun run seeds/insert-summaries-to-pgsql-prd.ts",
     "check-types": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest"

--- a/packages/db/seeds/insert-summaries-to-pgsql-prd.ts
+++ b/packages/db/seeds/insert-summaries-to-pgsql-prd.ts
@@ -1,0 +1,82 @@
+/**
+ * NDJSON サマリ結果を PostgreSQL DB に反映するスクリプト（本番用）
+ *
+ * data/minutes/{year}/{municipalityCode}/summaries.ndjson を読み込み、
+ * meetings テーブルの summary / topicDigests / summaryGeneratedAt / summaryModel を UPDATE する。
+ *
+ * 使い方:
+ *   DATABASE_URL_FOR_PRD_IMPORT="postgresql://..." bun run db:import:summaries:prd
+ *   DATABASE_URL_FOR_PRD_IMPORT="postgresql://..." bun run db:import:summaries:prd 462012  # 特定の自治体のみ
+ *   DATABASE_URL_FOR_PRD_IMPORT="postgresql://..." bun run db:import:summaries:prd --force  # フラグを無視して再 import
+ *
+ * - _summaries_complete に summariesImported フラグが立っていないディレクトリのみ処理する
+ * - 各ディレクトリの処理成功後に _summaries_complete を作成する
+ * - --force でフラグを無視して全ディレクトリ再処理（NDJSON が再生成された場合）
+ */
+
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import dotenv from "dotenv";
+import { createDb } from "../src/index";
+import { collectSummaryImportTargets } from "./utils/collect-summary-import-targets";
+import { importAllSummaries } from "./utils/summaries-import-runner";
+
+const seedsDir = dirname(fileURLToPath(import.meta.url));
+const root = resolve(seedsDir, "../../..");
+
+dotenv.config({ path: resolve(root, ".env.local"), override: true });
+
+const dataDir = resolve(root, "data/minutes");
+
+async function main() {
+  const databaseUrl = process.env.DATABASE_URL_FOR_PRD_IMPORT;
+  if (!databaseUrl) {
+    console.error("[import:summaries:prd] DATABASE_URL_FOR_PRD_IMPORT が設定されていません");
+    process.exit(1);
+  }
+
+  const args = process.argv.slice(2);
+  const force = args.includes("--force");
+  const municipalityCodes = args.filter((arg) => !arg.startsWith("-"));
+
+  if (municipalityCodes.length > 0) {
+    console.log(`[import:summaries:prd] 対象自治体コード: ${municipalityCodes.join(", ")}`);
+  }
+  if (force) {
+    console.log(`[import:summaries:prd] --force: summariesImported フラグを無視`);
+  }
+
+  const targets = collectSummaryImportTargets(dataDir, {
+    skipImported: !force,
+    municipalityCodes,
+  });
+
+  if (targets.length === 0) {
+    console.log(
+      "[import:summaries:prd] インポート対象なし（summaries.ndjson 未存在 or すべてインポート済み）",
+    );
+    process.exit(0);
+  }
+
+  console.log(
+    `[import:summaries:prd] ${targets.length} ディレクトリの summaries.ndjson を検出（未インポート）`,
+  );
+
+  const db = createDb(databaseUrl);
+  const { totalDirs, failedDirs, totalUpdated } = await importAllSummaries(db, targets, dataDir, {
+    markImported: true,
+  });
+
+  console.log("[import:summaries:prd] 完了!");
+  console.log(`  成功: ${totalDirs} ディレクトリ  UPDATE 件数: ${totalUpdated}`);
+  if (failedDirs > 0) {
+    console.log(`  失敗: ${failedDirs} ディレクトリ`);
+  }
+
+  process.exit(failedDirs > 0 ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error("[import:summaries:prd] Fatal error:", err);
+  process.exit(1);
+});

--- a/packages/db/seeds/insert-summaries-to-pgsql.ts
+++ b/packages/db/seeds/insert-summaries-to-pgsql.ts
@@ -1,0 +1,72 @@
+/**
+ * NDJSON サマリ結果を PostgreSQL DB に反映するスクリプト（ローカル用）
+ *
+ * data/minutes/{year}/{municipalityCode}/summaries.ndjson を読み込み、
+ * meetings テーブルの summary / topicDigests / summaryGeneratedAt / summaryModel を UPDATE する。
+ *
+ * 使い方:
+ *   DATABASE_URL="postgresql://..." bun run db:import:summaries
+ *   DATABASE_URL="postgresql://..." bun run db:import:summaries 462012  # 特定の自治体のみ
+ *
+ * - summaries.ndjson が存在するすべてのディレクトリを処理する（_summaries_complete は無視）
+ * - フラグの記録は行わない
+ * - 本番 DB へのインポートには db:import:summaries:prd を使用すること
+ */
+
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import dotenv from "dotenv";
+import { createDb } from "../src/index";
+import { collectSummaryImportTargets } from "./utils/collect-summary-import-targets";
+import { importAllSummaries } from "./utils/summaries-import-runner";
+
+const seedsDir = dirname(fileURLToPath(import.meta.url));
+const root = resolve(seedsDir, "../../..");
+
+dotenv.config({ path: resolve(root, ".env.local"), override: true });
+
+const dataDir = resolve(root, "data/minutes");
+
+async function main() {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    console.error("[import:summaries] DATABASE_URL が設定されていません");
+    process.exit(1);
+  }
+
+  const municipalityCodes = process.argv.slice(2).filter((arg) => !arg.startsWith("-"));
+
+  if (municipalityCodes.length > 0) {
+    console.log(`[import:summaries] 対象自治体コード: ${municipalityCodes.join(", ")}`);
+  }
+
+  const targets = collectSummaryImportTargets(dataDir, {
+    skipImported: false,
+    municipalityCodes,
+  });
+
+  if (targets.length === 0) {
+    console.log("[import:summaries] summaries.ndjson が見つかりません");
+    process.exit(0);
+  }
+
+  console.log(`[import:summaries] ${targets.length} ディレクトリの summaries.ndjson を検出`);
+
+  const db = createDb(databaseUrl);
+  const { totalDirs, failedDirs, totalUpdated } = await importAllSummaries(db, targets, dataDir, {
+    markImported: false,
+  });
+
+  console.log("[import:summaries] 完了!");
+  console.log(`  成功: ${totalDirs} ディレクトリ  UPDATE 件数: ${totalUpdated}`);
+  if (failedDirs > 0) {
+    console.log(`  失敗: ${failedDirs} ディレクトリ`);
+  }
+
+  process.exit(failedDirs > 0 ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error("[import:summaries] Fatal error:", err);
+  process.exit(1);
+});

--- a/packages/db/seeds/parse-data/summaries.ts
+++ b/packages/db/seeds/parse-data/summaries.ts
@@ -1,0 +1,18 @@
+import type { MeetingTopicDigest } from "../../src/schema/meetings";
+
+/** apps/meeting-summarizer 出力の summaries.ndjson 1 行に対応 */
+export type SummaryNdjsonRow = {
+  meetingId: string;
+  municipalityCode: string;
+  heldOn: string;
+  summary: string;
+  topicDigests: MeetingTopicDigest[];
+  summaryModel: string;
+  summaryGeneratedAt: string;
+};
+
+export function parseSummaryNdjsonLine(line: string): SummaryNdjsonRow | null {
+  const trimmed = line.trim();
+  if (!trimmed) return null;
+  return JSON.parse(trimmed) as SummaryNdjsonRow;
+}

--- a/packages/db/seeds/utils/collect-summary-import-targets.ts
+++ b/packages/db/seeds/utils/collect-summary-import-targets.ts
@@ -1,0 +1,54 @@
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { resolve } from "node:path";
+import { isSummariesAlreadyImported } from "./complete-marker";
+
+export interface SummaryImportTarget {
+  codeDir: string;
+  summariesPath: string;
+}
+
+export interface CollectSummaryOptions {
+  /** true の場合、summariesImported 済みディレクトリをスキップする（本番用） */
+  skipImported: boolean;
+  /** 指定した場合、この自治体コードに一致するディレクトリのみ対象にする */
+  municipalityCodes?: string[];
+}
+
+/**
+ * data/minutes/ 配下の {year}/{municipalityCode}/ ディレクトリを走査し、
+ * summaries.ndjson が存在するディレクトリを返す。
+ *
+ * skipImported: true の場合、_summaries_complete に summariesImported フラグが
+ * 立っているディレクトリを除外する。
+ */
+export function collectSummaryImportTargets(
+  dataDir: string,
+  options: CollectSummaryOptions,
+): SummaryImportTarget[] {
+  const targets: SummaryImportTarget[] = [];
+
+  if (!existsSync(dataDir)) return targets;
+
+  for (const yearEntry of readdirSync(dataDir)) {
+    const yearDir = resolve(dataDir, yearEntry);
+    if (!statSync(yearDir).isDirectory() || !/^\d{4}$/.test(yearEntry)) continue;
+
+    for (const codeEntry of readdirSync(yearDir)) {
+      const codeDir = resolve(yearDir, codeEntry);
+      if (!statSync(codeDir).isDirectory()) continue;
+
+      if (options.municipalityCodes && options.municipalityCodes.length > 0) {
+        if (!options.municipalityCodes.includes(codeEntry)) continue;
+      }
+
+      const summariesPath = resolve(codeDir, "summaries.ndjson");
+      if (!existsSync(summariesPath)) continue;
+
+      if (options.skipImported && isSummariesAlreadyImported(codeDir)) continue;
+
+      targets.push({ codeDir, summariesPath });
+    }
+  }
+
+  return targets;
+}

--- a/packages/db/seeds/utils/complete-marker.ts
+++ b/packages/db/seeds/utils/complete-marker.ts
@@ -25,3 +25,29 @@ export function markAsImported(codeDir: string): void {
   data.importedAt = new Date().toISOString();
   writeFileSync(completePath, JSON.stringify(data) + "\n");
 }
+
+/**
+ * _summaries_complete ファイルを読み取り、summariesImported フラグが立っているか確認する。
+ * summaries.ndjson の import 履歴は meetings.ndjson とは独立に管理する。
+ */
+export function isSummariesAlreadyImported(codeDir: string): boolean {
+  const path = resolve(codeDir, "_summaries_complete");
+  if (!existsSync(path)) return false;
+  try {
+    const data = JSON.parse(readFileSync(path, "utf-8"));
+    return data.summariesImported === true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * _summaries_complete ファイルに summariesImported フラグを書き込む。
+ */
+export function markSummariesAsImported(codeDir: string): void {
+  const path = resolve(codeDir, "_summaries_complete");
+  writeFileSync(
+    path,
+    JSON.stringify({ summariesImported: true, importedAt: new Date().toISOString() }) + "\n",
+  );
+}

--- a/packages/db/seeds/utils/summaries-import-runner.ts
+++ b/packages/db/seeds/utils/summaries-import-runner.ts
@@ -1,0 +1,112 @@
+import { createReadStream } from "node:fs";
+import { createInterface } from "node:readline";
+import { eq } from "drizzle-orm";
+import type { Db } from "../../src/index";
+import { meetings } from "../../src/schema/meetings";
+import { parseSummaryNdjsonLine, type SummaryNdjsonRow } from "../parse-data/summaries";
+import { markSummariesAsImported } from "./complete-marker";
+import type { SummaryImportTarget } from "./collect-summary-import-targets";
+
+export interface ImportSummariesOptions {
+  markImported: boolean;
+}
+
+export interface ImportSummariesResult {
+  totalDirs: number;
+  failedDirs: number;
+  totalUpdated: number;
+}
+
+export async function importAllSummaries(
+  db: Db,
+  targets: SummaryImportTarget[],
+  dataDir: string,
+  options: ImportSummariesOptions,
+): Promise<ImportSummariesResult> {
+  let totalDirs = 0;
+  let failedDirs = 0;
+  let totalUpdated = 0;
+
+  for (const target of targets) {
+    const label = target.codeDir.replace(dataDir + "/", "");
+    try {
+      const updated = await importSummariesDirectory(db, target.summariesPath, label);
+      if (options.markImported) {
+        markSummariesAsImported(target.codeDir);
+      }
+      totalDirs++;
+      totalUpdated += updated;
+      if (options.markImported) {
+        console.log(`[import:summaries] ${label} ${updated} 件 UPDATE 完了・フラグ記録`);
+      } else {
+        console.log(`[import:summaries] ${label} ${updated} 件 UPDATE 完了`);
+      }
+    } catch (err) {
+      failedDirs++;
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[import:summaries] ${label} 失敗: ${msg.slice(0, 300)}`);
+    }
+  }
+
+  return { totalDirs, failedDirs, totalUpdated };
+}
+
+async function importSummariesDirectory(
+  db: Db,
+  summariesPath: string,
+  label: string,
+): Promise<number> {
+  // ── バリデーションフェーズ ──
+  const rows: SummaryNdjsonRow[] = [];
+  let lineNo = 0;
+  for await (const line of createInterface({
+    input: createReadStream(summariesPath),
+    crlfDelay: Infinity,
+  })) {
+    lineNo++;
+    const row = parseSummaryNdjsonLine(line);
+    if (!row) continue;
+    if (!row.meetingId) {
+      throw new Error(`summaries.ndjson L${lineNo}: meetingId が未設定`);
+    }
+    if (typeof row.summary !== "string" || row.summary.length === 0) {
+      throw new Error(`summaries.ndjson L${lineNo} (meetingId=${row.meetingId}): summary が空`);
+    }
+    if (!Array.isArray(row.topicDigests)) {
+      throw new Error(
+        `summaries.ndjson L${lineNo} (meetingId=${row.meetingId}): topicDigests が配列でない`,
+      );
+    }
+    rows.push(row);
+  }
+
+  // 同一 meetingId が複数行ある場合、最後の行が勝つ
+  const dedup = new Map<string, SummaryNdjsonRow>();
+  for (const row of rows) {
+    dedup.set(row.meetingId, row);
+  }
+
+  // ── UPDATE フェーズ（バリデーション通過後のみ実行） ──
+  let updated = 0;
+  for (const row of dedup.values()) {
+    const result = await db
+      .update(meetings)
+      .set({
+        summary: row.summary,
+        topicDigests: row.topicDigests,
+        summaryGeneratedAt: new Date(row.summaryGeneratedAt),
+        summaryModel: row.summaryModel,
+      })
+      .where(eq(meetings.id, row.meetingId))
+      .returning({ id: meetings.id });
+    if (result.length > 0) {
+      updated++;
+    } else {
+      console.warn(
+        `[import:summaries]   ${label}: meetingId=${row.meetingId} に対応する meetings 行なし（skip）`,
+      );
+    }
+  }
+
+  return updated;
+}


### PR DESCRIPTION
## Summary

- `summarize:one` / `summarize:batch` の DB 直接 UPDATE を廃止し、サマリ結果を `data/minutes/{year}/{municipalityCode}/summaries.ndjson` に追記するよう変更（既存の meetings.ndjson / statements.ndjson と同じ NDJSON ベースの import フローに統一）
- 本番 DB 反映用の独立スクリプト `db:import:summaries` / `db:import:summaries:prd` を新設。`_summaries_complete` フラグで冪等性を担保（`--force` で再 import 可能）
- LLM 出力をローカルで確認してから本番に流す運用に切り替え、誤った内容を即時反映するリスクを排除

## 主な変更点

- `apps/meeting-summarizer/src/write-summary-ndjson.ts` 新規（並列 worker からの append を Promise チェーンで直列化）
- `summarize-one.ts`：`--write` フラグ廃止、`--dry-run` 追加（NDJSON にも書かない）
- `summarize-batch.ts`：DB UPDATE 削除、`appendSummaryRow()` 呼び出しに置換。`--skip-existing` は引き続き DB の `meetings.summary` を参照
- `packages/db/seeds/`: `summaries-import-runner.ts` で重複は最後の行が勝つ UPDATE。`_summaries_complete` は `_complete` とは独立管理
- `apps/meeting-summarizer/AGENTS.md`：「meetings テーブルへの読み書き」→ 読み取り専用、サマリは NDJSON 経由と明記

## Test plan

- [x] `bun run --cwd apps/meeting-summarizer test`（write-summary-ndjson の round-trip / 並列 50 行 / 不正 heldOn の 4 ケース追加、22 件 pass）
- [x] `bun run --cwd apps/meeting-summarizer check-types`
- [x] `bun run --cwd packages/db test` / `check-types`
- [x] `npx oxlint` 対象ファイル全部 pass
- [ ] ローカル end-to-end：`summarize:one --kagoshima-sample` → `summaries.ndjson` 確認 → `db:import:summaries 462012` で `meetings.summary` 反映を Drizzle Studio で確認（API キー必要なため未実施。マージ前に手元で実行推奨）

## 既知の事項

- `packages/api` の 3 件の test failure（`relation "statements" does not exist`）は本 PR の変更ではなく `50eb3571 chore(db): statements テーブルを削除` 由来の pre-existing。本 PR とは独立に修正が必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)