### PR TITLE
feat(meetings): ask を public 化し未ログインは IP 単位で 5 回/24h に制限

### DIFF
--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -9,6 +9,7 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as AskRouteImport } from './routes/ask'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as TopicsIndexRouteImport } from './routes/topics/index'
 import { Route as MeetingsIndexRouteImport } from './routes/meetings/index'
@@ -23,6 +24,11 @@ import { Route as ApiAuthSplatRouteImport } from './routes/api/auth/$'
 import { Route as AdminLayoutAskRouteImport } from './routes/admin/_layout/ask'
 import { Route as authSignUpOtpIndexRouteImport } from './routes/(auth)/sign-up/otp/index'
 
+const AskRoute = AskRouteImport.update({
+  id: '/ask',
+  path: '/ask',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
@@ -91,6 +97,7 @@ const authSignUpOtpIndexRoute = authSignUpOtpIndexRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/ask': typeof AskRoute
   '/admin': typeof AdminLayoutRouteWithChildren
   '/topics/$topic': typeof TopicsTopicRoute
   '/topics/compare': typeof TopicsCompareRoute
@@ -106,6 +113,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/ask': typeof AskRoute
   '/topics/$topic': typeof TopicsTopicRoute
   '/topics/compare': typeof TopicsCompareRoute
   '/meetings': typeof MeetingsIndexRoute
@@ -121,6 +129,7 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/ask': typeof AskRoute
   '/admin/_layout': typeof AdminLayoutRouteWithChildren
   '/topics/$topic': typeof TopicsTopicRoute
   '/topics/compare': typeof TopicsCompareRoute
@@ -138,6 +147,7 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/ask'
     | '/admin'
     | '/topics/$topic'
     | '/topics/compare'
@@ -153,6 +163,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/ask'
     | '/topics/$topic'
     | '/topics/compare'
     | '/meetings'
@@ -167,6 +178,7 @@ export interface FileRouteTypes {
   id:
     | '__root__'
     | '/'
+    | '/ask'
     | '/admin/_layout'
     | '/topics/$topic'
     | '/topics/compare'
@@ -183,6 +195,7 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  AskRoute: typeof AskRoute
   AdminLayoutRoute: typeof AdminLayoutRouteWithChildren
   TopicsTopicRoute: typeof TopicsTopicRoute
   TopicsCompareRoute: typeof TopicsCompareRoute
@@ -197,6 +210,13 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/ask': {
+      id: '/ask'
+      path: '/ask'
+      fullPath: '/ask'
+      preLoaderRoute: typeof AskRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -307,6 +327,7 @@ const AdminLayoutRouteWithChildren = AdminLayoutRoute._addFileChildren(
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  AskRoute: AskRoute,
   AdminLayoutRoute: AdminLayoutRouteWithChildren,
   TopicsTopicRoute: TopicsTopicRoute,
   TopicsCompareRoute: TopicsCompareRoute,
@@ -321,3 +342,12 @@ const rootRouteChildren: RootRouteChildren = {
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
+
+import type { getRouter } from './router.tsx'
+import type { createStart } from '@tanstack/react-start'
+declare module '@tanstack/react-start' {
+  interface Register {
+    ssr: true
+    router: Awaited<ReturnType<typeof getRouter>>
+  }
+}

--- a/apps/web/src/routes/admin/_layout/ask.tsx
+++ b/apps/web/src/routes/admin/_layout/ask.tsx
@@ -1,18 +1,12 @@
-import { useRef, useState } from "react";
+import { useState } from "react";
 import { createFileRoute } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
 
-import { client, orpc } from "@/lib/orpc/orpc";
+import { orpc } from "@/lib/orpc/orpc";
 import { Button } from "@/shared/_components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/shared/_components/ui/card";
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "@/shared/_components/ui/collapsible";
 import { Input } from "@/shared/_components/ui/input";
 import { Label } from "@/shared/_components/ui/label";
-import { Textarea } from "@/shared/_components/ui/textarea";
 import { MunicipalitySelector } from "@/shared/_components/municipality-selector";
 
 export const Route = createFileRoute("/admin/_layout/ask")({
@@ -24,7 +18,6 @@ function AdminAskPage() {
     <div className="mx-auto max-w-6xl px-4 py-8 space-y-8">
       <h1 className="text-2xl font-bold">Ask 動作確認</h1>
       <TopicsSearchSection />
-      <MeetingsAskSection />
       <TopicsTimelineSection />
       <TopicsCompareSection />
     </div>
@@ -84,9 +77,7 @@ function TopicsSearchSection() {
           </div>
         </form>
 
-        {error && (
-          <p className="text-sm text-destructive">エラー: {error.message}</p>
-        )}
+        {error && <p className="text-sm text-destructive">エラー: {error.message}</p>}
 
         {enabled && (
           <div className="space-y-2">
@@ -114,207 +105,6 @@ function TopicsSearchSection() {
                 </CardContent>
               </Card>
             ))}
-          </div>
-        )}
-      </CardContent>
-    </Card>
-  );
-}
-
-interface AskProgressEntry {
-  iteration: number;
-  tool: string;
-  args: unknown;
-  resultSummary: string | null;
-}
-
-interface AskFinalResult {
-  answer: string;
-  iterations: number;
-  inputTokens: number;
-  outputTokens: number;
-  trace: { tool: string; args: unknown; resultSummary: string }[];
-}
-
-function MeetingsAskSection() {
-  const [municipalityCode, setMunicipalityCode] = useState("");
-  const [question, setQuestion] = useState("");
-  const [isStreaming, setIsStreaming] = useState(false);
-  const [progress, setProgress] = useState<AskProgressEntry[]>([]);
-  const [currentIteration, setCurrentIteration] = useState<number | null>(null);
-  const [finalResult, setFinalResult] = useState<AskFinalResult | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const abortRef = useRef<AbortController | null>(null);
-
-  const onSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!question.trim() || isStreaming) return;
-
-    // 以前のリクエストをキャンセル
-    abortRef.current?.abort();
-    const controller = new AbortController();
-    abortRef.current = controller;
-
-    setIsStreaming(true);
-    setProgress([]);
-    setCurrentIteration(null);
-    setFinalResult(null);
-    setError(null);
-
-    try {
-      const stream = await client.meetings.askStream(
-        {
-          question: question.trim(),
-          municipalityCode: municipalityCode.trim() || undefined,
-        },
-        { signal: controller.signal },
-      );
-
-      for await (const event of stream) {
-        if (event.type === "iteration_start") {
-          setCurrentIteration(event.iteration);
-        } else if (event.type === "tool_call") {
-          setProgress((prev) => [
-            ...prev,
-            {
-              iteration: event.iteration,
-              tool: event.tool,
-              args: event.args,
-              resultSummary: null,
-            },
-          ]);
-        } else if (event.type === "tool_result") {
-          setProgress((prev) => {
-            // 同じ iteration + tool の最後の未確定エントリを更新する
-            const next = [...prev];
-            for (let i = next.length - 1; i >= 0; i--) {
-              const entry = next[i]!;
-              if (
-                entry.iteration === event.iteration &&
-                entry.tool === event.tool &&
-                entry.resultSummary === null
-              ) {
-                next[i] = { ...entry, resultSummary: event.resultSummary };
-                break;
-              }
-            }
-            return next;
-          });
-        } else if (event.type === "done") {
-          setFinalResult(event.result);
-        }
-      }
-    } catch (err) {
-      if (controller.signal.aborted) return;
-      setError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setIsStreaming(false);
-    }
-  };
-
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle>エージェントに質問</CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        <form onSubmit={onSubmit} className="space-y-3">
-          <div className="flex flex-col gap-2">
-            <Label htmlFor="ask-municipality">自治体コード（任意・単一）</Label>
-            <Input
-              id="ask-municipality"
-              value={municipalityCode}
-              onChange={(e) => setMunicipalityCode(e.target.value)}
-              placeholder="例: 462012"
-            />
-          </div>
-          <div className="flex flex-col gap-2">
-            <Label htmlFor="ask-question">質問</Label>
-            <Textarea
-              id="ask-question"
-              value={question}
-              onChange={(e) => setQuestion(e.target.value)}
-              placeholder="例: 市バス路線再編について時系列で整理して"
-              rows={5}
-            />
-          </div>
-          <Button type="submit" disabled={!question.trim() || isStreaming}>
-            {isStreaming
-              ? `問い合わせ中... (iter ${currentIteration ?? "-"})`
-              : "聞く"}
-          </Button>
-        </form>
-
-        {error && <p className="text-sm text-destructive">エラー: {error}</p>}
-
-        {(isStreaming || progress.length > 0) && (
-          <div className="space-y-2">
-            <div className="text-xs text-muted-foreground">
-              進捗 ({progress.length} 件のツール呼び出し)
-            </div>
-            {progress.map((entry, idx) => (
-              <Card key={idx} className="border">
-                <CardContent className="py-2 space-y-1 text-xs">
-                  <div className="font-semibold">
-                    iter #{entry.iteration} · {entry.tool}
-                  </div>
-                  <div className="font-mono text-muted-foreground break-all">
-                    args: {JSON.stringify(entry.args)}
-                  </div>
-                  <div className="text-muted-foreground">
-                    result:{" "}
-                    {entry.resultSummary ?? (
-                      <span className="italic">実行中...</span>
-                    )}
-                  </div>
-                </CardContent>
-              </Card>
-            ))}
-          </div>
-        )}
-
-        {finalResult && (
-          <div className="space-y-3">
-            <div className="flex gap-4 text-xs text-muted-foreground">
-              <span>iterations: {finalResult.iterations}</span>
-              <span>input tokens: {finalResult.inputTokens}</span>
-              <span>output tokens: {finalResult.outputTokens}</span>
-            </div>
-            <Card className="border">
-              <CardHeader className="pb-2">
-                <CardTitle className="text-sm">回答</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <pre className="whitespace-pre-wrap text-sm font-sans">
-                  {finalResult.answer}
-                </pre>
-              </CardContent>
-            </Card>
-
-            <Collapsible>
-              <CollapsibleTrigger asChild>
-                <Button variant="outline" size="sm">
-                  trace を表示 ({finalResult.trace.length} 件)
-                </Button>
-              </CollapsibleTrigger>
-              <CollapsibleContent className="mt-2 space-y-2">
-                {finalResult.trace.map((t, idx) => (
-                  <Card key={idx} className="border">
-                    <CardContent className="py-2 space-y-1 text-xs">
-                      <div className="font-semibold">
-                        #{idx + 1} {t.tool}
-                      </div>
-                      <div className="font-mono text-muted-foreground break-all">
-                        args: {JSON.stringify(t.args)}
-                      </div>
-                      <div className="text-muted-foreground">
-                        result: {t.resultSummary}
-                      </div>
-                    </CardContent>
-                  </Card>
-                ))}
-              </CollapsibleContent>
-            </Collapsible>
           </div>
         )}
       </CardContent>

--- a/apps/web/src/routes/ask.tsx
+++ b/apps/web/src/routes/ask.tsx
@@ -1,0 +1,215 @@
+import { useRef, useState } from "react";
+import { createFileRoute } from "@tanstack/react-router";
+
+import { client } from "@/lib/orpc/orpc";
+import { MunicipalitySelector } from "@/shared/_components/municipality-selector";
+import { Button } from "@/shared/_components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/shared/_components/ui/card";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/shared/_components/ui/collapsible";
+import { Label } from "@/shared/_components/ui/label";
+import { Textarea } from "@/shared/_components/ui/textarea";
+
+export const Route = createFileRoute("/ask")({
+  component: AskPage,
+});
+
+interface AskProgressEntry {
+  iteration: number;
+  tool: string;
+  args: unknown;
+  resultSummary: string | null;
+}
+
+interface AskFinalResult {
+  answer: string;
+  iterations: number;
+  inputTokens: number;
+  outputTokens: number;
+  trace: { tool: string; args: unknown; resultSummary: string }[];
+}
+
+function AskPage() {
+  const [selectedCodes, setSelectedCodes] = useState<string[]>([]);
+  const [question, setQuestion] = useState("");
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [progress, setProgress] = useState<AskProgressEntry[]>([]);
+  const [currentIteration, setCurrentIteration] = useState<number | null>(null);
+  const [finalResult, setFinalResult] = useState<AskFinalResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!question.trim() || isStreaming) return;
+
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    setIsStreaming(true);
+    setProgress([]);
+    setCurrentIteration(null);
+    setFinalResult(null);
+    setError(null);
+
+    try {
+      const stream = await client.meetings.askStream(
+        {
+          question: question.trim(),
+          municipalityCode: selectedCodes[0],
+        },
+        { signal: controller.signal },
+      );
+
+      for await (const event of stream) {
+        if (event.type === "iteration_start") {
+          setCurrentIteration(event.iteration);
+        } else if (event.type === "tool_call") {
+          setProgress((prev) => [
+            ...prev,
+            {
+              iteration: event.iteration,
+              tool: event.tool,
+              args: event.args,
+              resultSummary: null,
+            },
+          ]);
+        } else if (event.type === "tool_result") {
+          setProgress((prev) => {
+            const next = [...prev];
+            for (let i = next.length - 1; i >= 0; i--) {
+              const entry = next[i]!;
+              if (
+                entry.iteration === event.iteration &&
+                entry.tool === event.tool &&
+                entry.resultSummary === null
+              ) {
+                next[i] = { ...entry, resultSummary: event.resultSummary };
+                break;
+              }
+            }
+            return next;
+          });
+        } else if (event.type === "done") {
+          setFinalResult(event.result);
+        }
+      }
+    } catch (err) {
+      if (controller.signal.aborted) return;
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setIsStreaming(false);
+    }
+  };
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-8 space-y-6">
+      <div className="space-y-2">
+        <h1 className="text-2xl font-bold">議会 AI に質問する</h1>
+        <p className="text-sm text-muted-foreground">
+          自治体を絞り込んで、議会議事録をもとに質問できます。未ログインの場合、同一 IP から 24
+          時間あたり 5 回までご利用いただけます。
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>質問する</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <form onSubmit={onSubmit} className="space-y-4">
+            <div className="space-y-1">
+              <MunicipalitySelector selectedCodes={selectedCodes} onChange={setSelectedCodes} />
+              <p className="text-xs text-muted-foreground">
+                複数選択しても先頭 1 件のみ検索条件に使われます。空のままでも質問できます。
+              </p>
+            </div>
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="ask-question">質問</Label>
+              <Textarea
+                id="ask-question"
+                value={question}
+                onChange={(e) => setQuestion(e.target.value)}
+                placeholder="例: 市バス路線再編について時系列で整理して"
+                rows={5}
+              />
+            </div>
+            <Button type="submit" disabled={!question.trim() || isStreaming}>
+              {isStreaming ? `問い合わせ中... (iter ${currentIteration ?? "-"})` : "聞く"}
+            </Button>
+          </form>
+
+          {error && <p className="text-sm text-destructive">エラー: {error}</p>}
+
+          {(isStreaming || progress.length > 0) && (
+            <div className="space-y-2">
+              <div className="text-xs text-muted-foreground">
+                進捗 ({progress.length} 件のツール呼び出し)
+              </div>
+              {progress.map((entry, idx) => (
+                <Card key={idx} className="border">
+                  <CardContent className="py-2 space-y-1 text-xs">
+                    <div className="font-semibold">
+                      iter #{entry.iteration} · {entry.tool}
+                    </div>
+                    <div className="font-mono text-muted-foreground break-all">
+                      args: {JSON.stringify(entry.args)}
+                    </div>
+                    <div className="text-muted-foreground">
+                      result: {entry.resultSummary ?? <span className="italic">実行中...</span>}
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          )}
+
+          {finalResult && (
+            <div className="space-y-3">
+              <div className="flex gap-4 text-xs text-muted-foreground">
+                <span>iterations: {finalResult.iterations}</span>
+                <span>input tokens: {finalResult.inputTokens}</span>
+                <span>output tokens: {finalResult.outputTokens}</span>
+              </div>
+              <Card className="border">
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-sm">回答</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <pre className="whitespace-pre-wrap text-sm font-sans">{finalResult.answer}</pre>
+                </CardContent>
+              </Card>
+
+              <Collapsible>
+                <CollapsibleTrigger asChild>
+                  <Button variant="outline" size="sm">
+                    trace を表示 ({finalResult.trace.length} 件)
+                  </Button>
+                </CollapsibleTrigger>
+                <CollapsibleContent className="mt-2 space-y-2">
+                  {finalResult.trace.map((t, idx) => (
+                    <Card key={idx} className="border">
+                      <CardContent className="py-2 space-y-1 text-xs">
+                        <div className="font-semibold">
+                          #{idx + 1} {t.tool}
+                        </div>
+                        <div className="font-mono text-muted-foreground break-all">
+                          args: {JSON.stringify(t.args)}
+                        </div>
+                        <div className="text-muted-foreground">result: {t.resultSummary}</div>
+                      </CardContent>
+                    </Card>
+                  ))}
+                </CollapsibleContent>
+              </Collapsible>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/shared/_components/header.tsx
+++ b/apps/web/src/shared/_components/header.tsx
@@ -2,16 +2,12 @@ import { useState } from "react";
 import { Link, useRouterState } from "@tanstack/react-router";
 
 import UserMenu from "./user-menu";
-import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-} from "./ui/sheet";
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "./ui/sheet";
 import { FileSearch, Menu } from "lucide-react";
 
 const links = [
   { to: "/meetings", label: "会議一覧" },
+  { to: "/ask", label: "AI に質問" },
 ] as const;
 
 function NavLink({
@@ -53,11 +49,7 @@ export default function Header() {
           </Link>
           <nav className="hidden min-[481px]:flex items-center gap-1">
             {links.map(({ to, label }) => (
-              <NavLink
-                key={to}
-                to={to}
-                isActive={location.pathname.startsWith(to)}
-              >
+              <NavLink key={to} to={to} isActive={location.pathname.startsWith(to)}>
                 {label}
               </NavLink>
             ))}

--- a/packages/api/src/context.ts
+++ b/packages/api/src/context.ts
@@ -14,9 +14,11 @@ export async function createContext({ req, auth, db }: CreateContextParams) {
   const session = await auth.api.getSession({
     headers: req.headers,
   });
+  const ip = req.headers.get("cf-connecting-ip") ?? null;
   return {
     session,
     db,
+    ip,
   };
 }
 

--- a/packages/api/src/routers/meetings/meetings.router.ts
+++ b/packages/api/src/routers/meetings/meetings.router.ts
@@ -1,7 +1,9 @@
-import { eventIterator } from "@orpc/server";
+import { eventIterator, ORPCError } from "@orpc/server";
 import { z } from "zod";
 
-import { protectedProcedure, publicProcedure } from "../../index";
+import type { Context } from "../../context";
+import { publicProcedure } from "../../index";
+import { enforceGuestAskRateLimit } from "../../shared/guest-ask-rate-limit";
 import { checkRateLimit } from "../../shared/rate-limit";
 import { meetingsAskSchema, meetingsListSchema } from "./_schemas";
 import {
@@ -11,10 +13,20 @@ import {
   type AskMeetingsStreamEvent,
 } from "./meetings.service";
 
-const ASK_RATE_LIMIT = { windowMs: 10 * 60 * 1000, max: 5 } as const;
+const USER_ASK_RATE_LIMIT = { windowMs: 10 * 60 * 1000, max: 5 } as const;
+const GUEST_ASK_RATE_LIMIT = { windowMs: 24 * 60 * 60 * 1000, max: 5 } as const;
 
-function enforceAskRateLimit(userId: string): void {
-  checkRateLimit(`meetings.ask:${userId}`, ASK_RATE_LIMIT);
+async function enforceAskRateLimit(context: Context): Promise<void> {
+  if (context.session?.user) {
+    checkRateLimit(`meetings.ask:${context.session.user.id}`, USER_ASK_RATE_LIMIT);
+    return;
+  }
+  if (!context.ip) {
+    throw new ORPCError("TOO_MANY_REQUESTS", {
+      message: "送信元 IP を特定できないため、サインインしてから再試行してください。",
+    });
+  }
+  await enforceGuestAskRateLimit(context.db, context.ip, GUEST_ASK_RATE_LIMIT);
 }
 
 export const meetingsRouter = {
@@ -22,16 +34,16 @@ export const meetingsRouter = {
     .input(meetingsListSchema)
     .handler(({ input, context }) => listMeetings(context.db, input)),
 
-  ask: protectedProcedure.input(meetingsAskSchema).handler(({ input, context }) => {
-    enforceAskRateLimit(context.session.user.id);
+  ask: publicProcedure.input(meetingsAskSchema).handler(async ({ input, context }) => {
+    await enforceAskRateLimit(context);
     return askMeetings(context.db, input);
   }),
 
-  askStream: protectedProcedure
+  askStream: publicProcedure
     .input(meetingsAskSchema)
     .output(eventIterator(z.custom<AskMeetingsStreamEvent>()))
     .handler(async function* ({ input, context }) {
-      enforceAskRateLimit(context.session.user.id);
+      await enforceAskRateLimit(context);
       yield* askMeetingsStream(context.db, input);
     }),
 };

--- a/packages/api/src/shared/guest-ask-rate-limit.test.ts
+++ b/packages/api/src/shared/guest-ask-rate-limit.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { ORPCError } from "@orpc/server";
+
+import {
+  getTestDb,
+  withRollback,
+  createTestDatabase,
+  runMigrations,
+  closeTestDb,
+} from "@open-gikai/db/test-helpers";
+import { guest_ask_usage } from "@open-gikai/db/schema";
+
+import { enforceGuestAskRateLimit } from "./guest-ask-rate-limit";
+
+type TestDb = ReturnType<typeof getTestDb>;
+
+let db: TestDb;
+
+beforeAll(async () => {
+  await createTestDatabase();
+  db = getTestDb();
+  await runMigrations(db);
+});
+
+afterAll(async () => {
+  await closeTestDb(db);
+});
+
+describe("enforceGuestAskRateLimit", () => {
+  it("上限未満は通り、使用履歴を insert する", async () => {
+    await withRollback(db, async (tx) => {
+      const result = await enforceGuestAskRateLimit(tx, "1.2.3.4", {
+        windowMs: 24 * 60 * 60 * 1000,
+        max: 5,
+      });
+
+      expect(result.remaining).toBe(4);
+      const rows = await tx.select().from(guest_ask_usage);
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.ip).toBe("1.2.3.4");
+    });
+  });
+
+  it("ウィンドウ内で max 件を超えると TOO_MANY_REQUESTS を投げる", async () => {
+    await withRollback(db, async (tx) => {
+      const now = new Date("2026-04-20T00:00:00Z");
+      for (let i = 0; i < 5; i++) {
+        await enforceGuestAskRateLimit(
+          tx,
+          "5.6.7.8",
+          { windowMs: 24 * 60 * 60 * 1000, max: 5 },
+          new Date(now.getTime() + i),
+        );
+      }
+
+      try {
+        await enforceGuestAskRateLimit(
+          tx,
+          "5.6.7.8",
+          { windowMs: 24 * 60 * 60 * 1000, max: 5 },
+          new Date(now.getTime() + 1000),
+        );
+        expect.fail("should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(ORPCError);
+        expect((err as ORPCError<string, unknown>).code).toBe("TOO_MANY_REQUESTS");
+      }
+    });
+  });
+
+  it("異なる IP は独立してカウントされる", async () => {
+    await withRollback(db, async (tx) => {
+      for (let i = 0; i < 5; i++) {
+        await enforceGuestAskRateLimit(tx, "10.0.0.1", {
+          windowMs: 24 * 60 * 60 * 1000,
+          max: 5,
+        });
+      }
+
+      const result = await enforceGuestAskRateLimit(tx, "10.0.0.2", {
+        windowMs: 24 * 60 * 60 * 1000,
+        max: 5,
+      });
+
+      expect(result.remaining).toBe(4);
+    });
+  });
+
+  it("ウィンドウ外の古い履歴はカウントから除外される", async () => {
+    await withRollback(db, async (tx) => {
+      const long_ago = new Date("2026-04-01T00:00:00Z");
+      const now = new Date("2026-04-20T00:00:00Z");
+      const windowMs = 24 * 60 * 60 * 1000;
+
+      // ウィンドウ外 5 件
+      for (let i = 0; i < 5; i++) {
+        await tx.insert(guest_ask_usage).values({
+          ip: "20.0.0.1",
+          createdAt: new Date(long_ago.getTime() + i),
+        });
+      }
+
+      const result = await enforceGuestAskRateLimit(tx, "20.0.0.1", { windowMs, max: 5 }, now);
+
+      expect(result.remaining).toBe(4);
+    });
+  });
+});

--- a/packages/api/src/shared/guest-ask-rate-limit.ts
+++ b/packages/api/src/shared/guest-ask-rate-limit.ts
@@ -1,0 +1,56 @@
+import { and, eq, gt } from "drizzle-orm";
+import { ORPCError } from "@orpc/server";
+
+import type { Db } from "@open-gikai/db";
+import { guest_ask_usage } from "@open-gikai/db/schema";
+
+import type { RateLimitOptions } from "./rate-limit";
+
+/**
+ * 未ログインユーザーの meetings.ask 呼び出しを IP 単位で rolling window 制限する。
+ *
+ * `guest_ask_usage` テーブルに永続化するので、Worker の isolate 間や再起動をまたいで
+ * カウントが共有される。上限超過時は `ORPCError("TOO_MANY_REQUESTS")` を投げる。
+ */
+export async function enforceGuestAskRateLimit(
+  db: Db,
+  ip: string,
+  options: RateLimitOptions,
+  now: Date = new Date(),
+): Promise<{ remaining: number; resetAt: number }> {
+  const { windowMs, max } = options;
+  if (max <= 0) {
+    throw new ORPCError("TOO_MANY_REQUESTS", {
+      message: "Rate limit is disabled",
+    });
+  }
+
+  const windowStart = new Date(now.getTime() - windowMs);
+
+  const recentRows = await db
+    .select({ createdAt: guest_ask_usage.createdAt })
+    .from(guest_ask_usage)
+    .where(and(eq(guest_ask_usage.ip, ip), gt(guest_ask_usage.createdAt, windowStart)))
+    .orderBy(guest_ask_usage.createdAt);
+
+  if (recentRows.length >= max) {
+    const oldest = recentRows[0]!.createdAt;
+    const retryAfterMs = Math.max(0, oldest.getTime() + windowMs - now.getTime());
+    const seconds = Math.ceil(retryAfterMs / 1000);
+    throw new ORPCError("TOO_MANY_REQUESTS", {
+      message: `ゲストの検索上限（${max} 回 / ${Math.round(windowMs / 3600000)} 時間）に達しました。約 ${seconds} 秒後に再試行するか、サインインしてください。`,
+      data: {
+        retryAfterMs,
+        limit: max,
+        windowMs,
+      },
+    });
+  }
+
+  await db.insert(guest_ask_usage).values({ ip });
+
+  return {
+    remaining: max - recentRows.length - 1,
+    resetAt: (recentRows[0]?.createdAt.getTime() ?? now.getTime()) + windowMs,
+  };
+}

--- a/packages/db/src/migrations/0009_numerous_retro_girl.sql
+++ b/packages/db/src/migrations/0009_numerous_retro_girl.sql
@@ -1,0 +1,7 @@
+CREATE TABLE "guest_ask_usage" (
+	"id" text PRIMARY KEY NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"ip" text NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX "guest_ask_usage_ip_created_at_index" ON "guest_ask_usage" USING btree ("ip","created_at");

--- a/packages/db/src/migrations/meta/0009_snapshot.json
+++ b/packages/db/src/migrations/meta/0009_snapshot.json
@@ -1,0 +1,921 @@
+{
+  "id": "ba2ac9c4-e0b3-41fe-a30f-dc32248bd6c5",
+  "prevId": "b32db1a0-b646-4b63-8dfb-b7c105726f4e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "accounts_user_id_index": {
+          "name": "accounts_user_id_index",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sessions_user_id_index": {
+          "name": "sessions_user_id_index",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "verifications_identifier_index": {
+          "name": "verifications_identifier_index",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.municipalities": {
+      "name": "municipalities",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefecture": {
+          "name": "prefecture",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "population": {
+          "name": "population",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "population_year": {
+          "name": "population_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "municipalities_code_index": {
+          "name": "municipalities_code_index",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "municipalities_prefecture_index": {
+          "name": "municipalities_prefecture_index",
+          "columns": [
+            {
+              "expression": "prefecture",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meetings": {
+      "name": "meetings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "municipality_code": {
+          "name": "municipality_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meeting_type": {
+          "name": "meeting_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "held_on": {
+          "name": "held_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topic_digests": {
+          "name": "topic_digests",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_generated_at": {
+          "name": "summary_generated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_model": {
+          "name": "summary_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "meetings_municipality_code_external_id_index": {
+          "name": "meetings_municipality_code_external_id_index",
+          "columns": [
+            {
+              "expression": "municipality_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "meetings_held_on_index": {
+          "name": "meetings_held_on_index",
+          "columns": [
+            {
+              "expression": "held_on",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "meetings_meeting_type_held_on_index": {
+          "name": "meetings_meeting_type_held_on_index",
+          "columns": [
+            {
+              "expression": "meeting_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "held_on",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "meetings_municipality_code_held_on_index": {
+          "name": "meetings_municipality_code_held_on_index",
+          "columns": [
+            {
+              "expression": "municipality_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "held_on",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "meetings_municipality_code_municipalities_code_fk": {
+          "name": "meetings_municipality_code_municipalities_code_fk",
+          "tableFrom": "meetings",
+          "tableTo": "municipalities",
+          "columnsFrom": ["municipality_code"],
+          "columnsTo": ["code"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meeting_topics": {
+      "name": "meeting_topics",
+      "schema": "",
+      "columns": {
+        "meeting_id": {
+          "name": "meeting_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relevance": {
+          "name": "relevance",
+          "type": "topic_relevance",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "digest": {
+          "name": "digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "meeting_topics_topic_id_index": {
+          "name": "meeting_topics_topic_id_index",
+          "columns": [
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "meeting_topics_meeting_id_meetings_id_fk": {
+          "name": "meeting_topics_meeting_id_meetings_id_fk",
+          "tableFrom": "meeting_topics",
+          "tableTo": "meetings",
+          "columnsFrom": ["meeting_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "meeting_topics_topic_id_topics_id_fk": {
+          "name": "meeting_topics_topic_id_topics_id_fk",
+          "tableFrom": "meeting_topics",
+          "tableTo": "topics",
+          "columnsFrom": ["topic_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "meeting_topics_meeting_id_topic_id_pk": {
+          "name": "meeting_topics_meeting_id_topic_id_pk",
+          "columns": ["meeting_id", "topic_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topics": {
+      "name": "topics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "municipality_code": {
+          "name": "municipality_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_name": {
+          "name": "canonical_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aliases": {
+          "name": "aliases",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "topics_municipality_code_canonical_name_index": {
+          "name": "topics_municipality_code_canonical_name_index",
+          "columns": [
+            {
+              "expression": "municipality_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "canonical_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topics_municipality_code_index": {
+          "name": "topics_municipality_code_index",
+          "columns": [
+            {
+              "expression": "municipality_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "topics_municipality_code_municipalities_code_fk": {
+          "name": "topics_municipality_code_municipalities_code_fk",
+          "tableFrom": "topics",
+          "tableTo": "municipalities",
+          "columnsFrom": ["municipality_code"],
+          "columnsTo": ["code"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.guest_ask_usage": {
+      "name": "guest_ask_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "guest_ask_usage_ip_created_at_index": {
+          "name": "guest_ask_usage_ip_created_at_index",
+          "columns": [
+            {
+              "expression": "ip",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.topic_relevance": {
+      "name": "topic_relevance",
+      "schema": "public",
+      "values": ["primary", "secondary"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1776589874241,
       "tag": "0008_aspiring_thunderbolt",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1776614286032,
+      "tag": "0009_numerous_retro_girl",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -2,3 +2,4 @@ export * from "./auth";
 export * from "./municipalities";
 export * from "./meetings";
 export * from "./topics";
+export * from "./rate-limit";

--- a/packages/db/src/schema/rate-limit.ts
+++ b/packages/db/src/schema/rate-limit.ts
@@ -1,0 +1,18 @@
+import { pgTable, text, timestamp, index } from "drizzle-orm/pg-core";
+import { createId } from "@paralleldrive/cuid2";
+
+/**
+ * 未ログインユーザーが meetings.ask を叩いた履歴を IP 単位で保持する。
+ * 24 時間 rolling window で件数を数え、上限を超えたら拒否する用途。
+ */
+export const guest_ask_usage = pgTable(
+  "guest_ask_usage",
+  {
+    id: text()
+      .$defaultFn(() => createId())
+      .primaryKey(),
+    createdAt: timestamp().defaultNow().notNull(),
+    ip: text().notNull(),
+  },
+  (table) => [index().on(table.ip, table.createdAt)],
+);


### PR DESCRIPTION
## Summary

- `meetings.ask` / `askStream` を `protectedProcedure` → `publicProcedure` に切替。未ログインの場合は `guest_ask_usage` テーブルで IP 単位に rolling window（24h / 5 回）を enforce。認証済みユーザーは従来通り in-memory の 10 分 5 回制限を使用。
- admin 専用だった ask UI を公開ルート `/ask` に切り出し。自治体絞り込みを `MunicipalitySelector` に差し替えてチャット欄に追加。ヘッダーにも導線を追加。
- DB スキーマに `guest_ask_usage (id, created_at, ip)` テーブルと `(ip, created_at)` の複合 index を追加（migration 0009）。

## 主な変更

- `packages/db/src/schema/rate-limit.ts` — `guest_ask_usage` テーブル新設
- `packages/api/src/context.ts` — `cf-connecting-ip` ヘッダを `context.ip` として公開
- `packages/api/src/shared/guest-ask-rate-limit.ts` — DB バックの IP レートリミット関数 + テスト
- `packages/api/src/routers/meetings/meetings.router.ts` — session 有無で制限方式を分岐
- `apps/web/src/routes/ask.tsx` — 公開 ask ページ新設（admin 側からは削除）

## Test plan

- [x] `bun run agent:check` 通過（既存 50 + 新規 4 = 54 tests）
- [ ] ローカルで `/ask` を未ログインで開き、5 回質問できること
- [ ] 6 回目で `TOO_MANY_REQUESTS` エラーになること
- [ ] ログインした状態では従来の 10 分 5 回制限で動くこと
- [ ] 自治体セレクタで選んだコードが質問に反映されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)